### PR TITLE
fix marcxml_in dir path in tests

### DIFF
--- a/dlts/test/wip_processor_test.rb
+++ b/dlts/test/wip_processor_test.rb
@@ -47,7 +47,7 @@ class WipProcessorTest < MiniTest::Unit::TestCase
     w.run
     assert(File.exists?(File.join(WORK_DIR, 'NNC')), "<003> dir not created")
     assert(File.exists?(File.join(WORK_DIR, 'NNC', "NNC_#{date_str}")), "<003>_<date_str> dir not created")
-    assert(File.exists?(File.join(WORK_DIR, 'NNC', "NNC_#{date_str}", 'marcxml')), "marcxml dir not created")
+    assert(File.exists?(File.join(WORK_DIR, 'NNC', "NNC_#{date_str}", 'marcxml_in')), "marcxml dir not created")
   end
 
   def test_run_method_copies_marcxml_file
@@ -55,7 +55,7 @@ class WipProcessorTest < MiniTest::Unit::TestCase
 
     w = WipProcessor.new(TEST_NNC_ONE)
     w.run
-    exp = File.join(WORK_DIR, 'NNC', "NNC_#{date_str}", 'marcxml', "NNC_3076855_marcxml.xml")
+    exp = File.join(WORK_DIR, 'NNC', "NNC_#{date_str}", 'marcxml_in', "NNC_3076855_marcxml.xml")
     assert(File.exists?(exp), "marcxml file not copied")
     assert(FileUtils.cmp(exp, File.join(NNC_V1, 'data', 'columbia_CU58888896_marcxml.xml')))
   end


### PR DESCRIPTION
Change from marcxml/ to marcxml_in/ was not reflected in wip_processor_test.rb file.
Corrected error.
