### PR TITLE
update Cornell MARCXML with corrected MARC 003 identifier

### DIFF
--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1009968_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1009968_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22      a 4500</leader>
       <controlfield tag="001">1009968</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140830190927.0</controlfield>
       <controlfield tag="008">860115s1981    ir            001 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1015395_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1015395_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22      a 4500</leader>
       <controlfield tag="001">1015395</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140830193556.0</controlfield>
       <controlfield tag="008">871006s1937    ua            000 0 arard</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1106471_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1106471_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22      a 4500</leader>
       <controlfield tag="001">1106471</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140829185418.0</controlfield>
       <controlfield tag="008">850116s1952    ua       b    000 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_114009_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_114009_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22     1  4500</leader>
       <controlfield tag="001">114009</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140908190904.0</controlfield>
       <controlfield tag="008">860522s1952    le a          000 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1189331_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1189331_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22     1  4500</leader>
       <controlfield tag="001">1189331</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140829225903.0</controlfield>
       <controlfield tag="008">861224s1928    ua a          000 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1649265_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1649265_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22      a 4500</leader>
       <controlfield tag="001">1649265</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20141022085430.0</controlfield>
       <controlfield tag="008">900123s1951    ua       b    000 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1649311_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1649311_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     mam a22      a 4500</leader>
       <controlfield tag="001">1649311</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140824214804.0</controlfield>
       <controlfield tag="008">850927s1966    iq       b    000 0 ara d</controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1649369_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1649369_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     mam a22      a 4500</leader>
       <controlfield tag="001">1649369</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140824214817.0</controlfield>
       <controlfield tag="008">850813s1950    ua b     b    000 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1651147_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1651147_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     mam a22      a 4500</leader>
       <controlfield tag="001">1651147</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140824215350.0</controlfield>
       <controlfield tag="008">820913m19599999iq a         f000 0 araxd</controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1651166_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1651166_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22      a 4500</leader>
       <controlfield tag="001">1651166</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140824215353.0</controlfield>
       <controlfield tag="008">900131s1968    iq af    b    001 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1651539_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1651539_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22      a 4500</leader>
       <controlfield tag="001">1651539</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140824215452.0</controlfield>
       <controlfield tag="008">900201s1932    le af         000 0bara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1651546_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1651546_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     mam a22      a 4500</leader>
       <controlfield tag="001">1651546</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140824215453.0</controlfield>
       <controlfield tag="008">860815s1951    ua ab    b    000 0 arard</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1651551_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1651551_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22      a 4500</leader>
       <controlfield tag="001">1651551</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140824215454.0</controlfield>
       <controlfield tag="008">900201s1952    le  a         001 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1651809_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1651809_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     mam a22      a 4500</leader>
       <controlfield tag="001">1651809</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140824215535.0</controlfield>
       <controlfield tag="008">821028n19501959mr            000 0 araod</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1651947_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1651947_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22      a 4500</leader>
       <controlfield tag="001">1651947</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140824215555.0</controlfield>
       <controlfield tag="008">900202s1955    iq       b    000 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1654432_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1654432_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22      a 4500</leader>
       <controlfield tag="001">1654432</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140824220350.0</controlfield>
       <controlfield tag="008">900213s1954    iq       b    000 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1655977_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1655977_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22      a 4500</leader>
       <controlfield tag="001">1655977</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140824220845.0</controlfield>
       <controlfield tag="008">900219s1962    iq            000 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1669574_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1669574_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22      a 4500</leader>
       <controlfield tag="001">1669574</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140824225049.0</controlfield>
       <controlfield tag="008">900403s1940    iq a          000 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1670066_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1670066_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     mam a22      a 4500</leader>
       <controlfield tag="001">1670066</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140824225226.0</controlfield>
       <controlfield tag="008">850712s1970    iq a     b    000 0 ara d</controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1670469_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1670469_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22      a 4500</leader>
       <controlfield tag="001">1670469</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140824225331.0</controlfield>
       <controlfield tag="008">900405s1948    iq       b    000 0bara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1670505_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1670505_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     mam a22      a 4500</leader>
       <controlfield tag="001">1670505</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140824225336.0</controlfield>
       <controlfield tag="008">800129s1964    iq h     b    000 0cara d</controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1670935_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1670935_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     mam a22      a 4500</leader>
       <controlfield tag="001">1670935</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140824225439.0</controlfield>
       <controlfield tag="008">901016s1955    ua       b    001 0caraod</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1676331_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1676331_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22        4500</leader>
       <controlfield tag="001">1676331</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140824231128.0</controlfield>
       <controlfield tag="008">900423s1965    ir a          000 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1677313_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1677313_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     mam a22      a 4500</leader>
       <controlfield tag="001">1677313</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140824231430.0</controlfield>
       <controlfield tag="008">850918s1968    iq       b    000 0 ara d</controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1680621_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1680621_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22      a 4500</leader>
       <controlfield tag="001">1680621</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140824232424.0</controlfield>
       <controlfield tag="008">900508s1952    iq af         000 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1681413_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1681413_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     mam a22      a 4500</leader>
       <controlfield tag="001">1681413</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140824232628.0</controlfield>
       <controlfield tag="008">820203s1934    ua            000 0 araod</controlfield>
       <datafield tag="025" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1682102_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1682102_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22      a 4500</leader>
       <controlfield tag="001">1682102</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140824232834.0</controlfield>
       <controlfield tag="008">900514s1952    ua            000 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1682443_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1682443_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22      a 4500</leader>
       <controlfield tag="001">1682443</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140824232935.0</controlfield>
       <controlfield tag="008">900515s1936    ua            000 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1683483_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1683483_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     mam a22      a 4500</leader>
       <controlfield tag="001">1683483</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140824233245.0</controlfield>
       <controlfield tag="008">880805s1948    ua c          000 0 arard</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1685209_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1685209_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22      a 4500</leader>
       <controlfield tag="001">1685209</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140824233741.0</controlfield>
       <controlfield tag="008">900525s1948    ua            000 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1685221_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1685221_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     mam a22      a 4500</leader>
       <controlfield tag="001">1685221</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140824233742.0</controlfield>
       <controlfield tag="008">920506s1952    le            000 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1685233_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1685233_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     mam a22      a 4500</leader>
       <controlfield tag="001">1685233</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140824233744.0</controlfield>
       <controlfield tag="008">910729s1952    ua b    r     000 0 araod</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1685922_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1685922_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     mam a22      a 4500</leader>
       <controlfield tag="001">1685922</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140824233939.0</controlfield>
       <controlfield tag="008">820923s1951    ua       b    000 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1686263_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1686263_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22      a 4500</leader>
       <controlfield tag="001">1686263</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140824234039.0</controlfield>
       <controlfield tag="008">900531s1951    ua            000 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1686266_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1686266_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22      a 4500</leader>
       <controlfield tag="001">1686266</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140824234039.0</controlfield>
       <controlfield tag="008">900531q1950    ua            000 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1686305_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1686305_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22      a 4500</leader>
       <controlfield tag="001">1686305</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140824234047.0</controlfield>
       <controlfield tag="008">900601s1953    ua            000 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1686464_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1686464_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22      a 4500</leader>
       <controlfield tag="001">1686464</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140824234119.0</controlfield>
       <controlfield tag="008">900601q1950    ua a          000 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1686473_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1686473_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     mam a22      a 4500</leader>
       <controlfield tag="001">1686473</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140824234121.0</controlfield>
       <controlfield tag="008">851031q19501959ku       b    000 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1740766_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1740766_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22      a 4500</leader>
       <controlfield tag="001">1740766</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140823203220.0</controlfield>
       <controlfield tag="008">900605m19509999ua            000 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1742300_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1742300_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22      a 4500</leader>
       <controlfield tag="001">1742300</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140823203904.0</controlfield>
       <controlfield tag="008">900611s1950    ua            000 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1743368_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1743368_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22      a 4500</leader>
       <controlfield tag="001">1743368</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140823204350.0</controlfield>
       <controlfield tag="008">900615s1953    le       b    000 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1743381_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1743381_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     mam a22      a 4500</leader>
       <controlfield tag="001">1743381</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140823204354.0</controlfield>
       <controlfield tag="008">900627q19501951ua       b    000 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1743690_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1743690_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22      a 4500</leader>
       <controlfield tag="001">1743690</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140823204456.0</controlfield>
       <controlfield tag="008">900618q1954    ua a          000 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1743749_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1743749_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22      a 4500</leader>
       <controlfield tag="001">1743749</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140823204515.0</controlfield>
       <controlfield tag="008">900618s1909    ua a          000 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1746479_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1746479_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22      a 4500</leader>
       <controlfield tag="001">1746479</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140916172223.0</controlfield>
       <controlfield tag="008">900628q1960    ir       i    000 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1747776_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1747776_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     mam a22      a 4500</leader>
       <controlfield tag="001">1747776</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140823210233.0</controlfield>
       <controlfield tag="008">920803q19001990mr            000 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1786985_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1786985_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22      a 4500</leader>
       <controlfield tag="001">1786985</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140823225843.0</controlfield>
       <controlfield tag="008">901025q18961897mr            000 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1818808_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1818808_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22      a 4500</leader>
       <controlfield tag="001">1818808</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140822201922.0</controlfield>
       <controlfield tag="008">870908s1983    ir h     b    000 0 arard</controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1880697_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1880697_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     mam a22      a 4500</leader>
       <controlfield tag="001">1880697</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140916172916.0</controlfield>
       <controlfield tag="008">890925q19811982ir            000 0 araod</controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1881271_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1881271_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     mam a22      a 4500</leader>
       <controlfield tag="001">1881271</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140822230616.0</controlfield>
       <controlfield tag="008">850722s1973    ir cf         000 0 arar </controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1884213_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1884213_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22      a 4500</leader>
       <controlfield tag="001">1884213</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140822232156.0</controlfield>
       <controlfield tag="008">910423q1947    ua       b    001 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1908552_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1908552_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22      a 4500</leader>
       <controlfield tag="001">1908552</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140820184418.0</controlfield>
       <controlfield tag="008">910508q19281929ua ab         001 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1908593_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1908593_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22      a 4500</leader>
       <controlfield tag="001">1908593</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140820184435.0</controlfield>
       <controlfield tag="008">910508m19559999ua            000 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1910202_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1910202_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     mam a22      a 4500</leader>
       <controlfield tag="001">1910202</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140820185439.0</controlfield>
       <controlfield tag="008">830113s1945    su            000 0 arard</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1910203_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1910203_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     mam a22     u  4500</leader>
       <controlfield tag="001">1910203</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140820185440.0</controlfield>
       <controlfield tag="008">850607m19599999ir            000 0carar </controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1910206_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1910206_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     mam a22      a 4500</leader>
       <controlfield tag="001">1910206</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140820185441.0</controlfield>
       <controlfield tag="008">890914s1955    ua       b    001 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1910611_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1910611_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     mam a22      a 4500</leader>
       <controlfield tag="001">1910611</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140820185722.0</controlfield>
       <controlfield tag="008">821108m19561971sy       i    000 0 araod</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1910691_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1910691_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22      a 4500</leader>
       <controlfield tag="001">1910691</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140820185746.0</controlfield>
       <controlfield tag="008">910516m19279999ua            001 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1911759_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1911759_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22      a 4500</leader>
       <controlfield tag="001">1911759</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140820190410.0</controlfield>
       <controlfield tag="008">910520s1960    iq            000 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1918784_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1918784_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     mam a22      a 4500</leader>
       <controlfield tag="001">1918784</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140820193807.0</controlfield>
       <controlfield tag="008">890413m19561957ir h     b    000 0 arar </controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1919123_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1919123_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     mam a22      a 4500</leader>
       <controlfield tag="001">1919123</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140820194034.0</controlfield>
       <controlfield tag="008">850717m19541958iq            000 0cara d</controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1920114_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1920114_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22      a 4500</leader>
       <controlfield tag="001">1920114</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140820194700.0</controlfield>
       <controlfield tag="008">910528s1955    ua       b    000 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1921234_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1921234_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     mam a22      a 4500</leader>
       <controlfield tag="001">1921234</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140820195344.0</controlfield>
       <controlfield tag="008">840709s1922    ua       b    000 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1926067_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1926067_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     mam a22      a 4500</leader>
       <controlfield tag="001">1926067</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140916173118.0</controlfield>
       <controlfield tag="008">861218s1940    ua h     b    001 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1926592_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1926592_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     mam a22      a 4500</leader>
       <controlfield tag="001">1926592</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140820202144.0</controlfield>
       <controlfield tag="008">850717s1911    ua a     b    000 0 ara d</controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1926604_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1926604_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     mam a22      a 4500</leader>
       <controlfield tag="001">1926604</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140820202148.0</controlfield>
       <controlfield tag="008">850918s1965    iq       b    000 0 ara d</controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1926606_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1926606_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     mam a22      a 4500</leader>
       <controlfield tag="001">1926606</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140820202149.0</controlfield>
       <controlfield tag="008">800812s1954    ua            000 0 arar </controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1926610_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1926610_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     mam a22      a 4500</leader>
       <controlfield tag="001">1926610</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140820202150.0</controlfield>
       <controlfield tag="008">860115q19501959ua            000 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1927971_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1927971_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     mam a22      a 4500</leader>
       <controlfield tag="001">1927971</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140820202755.0</controlfield>
       <controlfield tag="008">830121s1926    ua            000 0 arard</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1928254_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1928254_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22      a 4500</leader>
       <controlfield tag="001">1928254</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140820202905.0</controlfield>
       <controlfield tag="008">910625s1953    ua a     b    001 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1930285_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1930285_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     mam a22      a 4500</leader>
       <controlfield tag="001">1930285</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140820203721.0</controlfield>
       <controlfield tag="008">850325s1966    iq a     b    000 0cara d</controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1930299_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1930299_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     mam a22      a 4500</leader>
       <controlfield tag="001">1930299</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140820203724.0</controlfield>
       <controlfield tag="008">890718m19461949mr       b    000 0caraxd</controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1931246_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1931246_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     mam a22      a 4500</leader>
       <controlfield tag="001">1931246</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140820204045.0</controlfield>
       <controlfield tag="008">801011q19041905ua            000 0cara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1931268_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1931268_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22      a 4500</leader>
       <controlfield tag="001">1931268</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140820204049.0</controlfield>
       <controlfield tag="008">910709s1964    iq       b    001 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1932115_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1932115_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     mam a22     u  4500</leader>
       <controlfield tag="001">1932115</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140820204353.0</controlfield>
       <controlfield tag="008">860609s1965    iq ab    b    001 0 arar </controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1932518_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1932518_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     mam a22        4500</leader>
       <controlfield tag="001">1932518</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140820204506.0</controlfield>
       <controlfield tag="008">850610s1878    tu      a     000 0 araod</controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1932520_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1932520_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     mam a22      a 4500</leader>
       <controlfield tag="001">1932520</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140820204507.0</controlfield>
       <controlfield tag="008">860915s1949    sy       b    000 0 araod</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1932731_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1932731_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     mam a22      a 4500</leader>
       <controlfield tag="001">1932731</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140820204554.0</controlfield>
       <controlfield tag="008">850911s1953    ua            001 0 ara  </controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1933410_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1933410_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22      a 4500</leader>
       <controlfield tag="001">1933410</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140820204810.0</controlfield>
       <controlfield tag="008">910717q19501959ua       b    000 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1935407_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_1935407_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22      a 4500</leader>
       <controlfield tag="001">1935407</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140820205542.0</controlfield>
       <controlfield tag="008">910723q18991900le            000 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_2392294_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_2392294_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22        4500</leader>
       <controlfield tag="001">2392294</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140816231030.0</controlfield>
       <controlfield tag="008">921102m19701974iq h     b    000 0 arax </controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_2392320_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_2392320_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22      a 4500</leader>
       <controlfield tag="001">2392320</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140816231036.0</controlfield>
       <controlfield tag="008">921102s1965    iq            000 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_2817054_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_2817054_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     mam a22     1a 4500</leader>
       <controlfield tag="001">2817054</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140811193728.0</controlfield>
       <controlfield tag="008">941108s1955    ua       b    000 0 arar </controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_2853443_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_2853443_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     mam a22      a 4500</leader>
       <controlfield tag="001">2853443</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140811215625.0</controlfield>
       <controlfield tag="008">911209q19651966ir            000 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_2865229_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_2865229_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22        4500</leader>
       <controlfield tag="001">2865229</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140811223413.0</controlfield>
       <controlfield tag="008">911004s1965    iq            000 0 arar </controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_2865257_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_2865257_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22     ua 4500</leader>
       <controlfield tag="001">2865257</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140811223416.0</controlfield>
       <controlfield tag="008">850314s1969    iq            001 0 arar </controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_2865286_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_2865286_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22        4500</leader>
       <controlfield tag="001">2865286</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140811223420.0</controlfield>
       <controlfield tag="008">900323m19709999iq       b    000 0 arar </controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_2878280_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_2878280_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22     ua 4500</leader>
       <controlfield tag="001">2878280</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140811230945.0</controlfield>
       <controlfield tag="008">841204m19709999iq            001 0 arar </controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_2878282_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_2878282_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22     ua 4500</leader>
       <controlfield tag="001">2878282</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140811230945.0</controlfield>
       <controlfield tag="008">850311m19691970iq            001 0 arar </controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_2883679_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_2883679_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22     1  4500</leader>
       <controlfield tag="001">2883679</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140811232130.0</controlfield>
       <controlfield tag="008">851204m19681969iq            ||| | ara d</controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_2883747_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_2883747_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22     1i 4500</leader>
       <controlfield tag="001">2883747</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140811232141.0</controlfield>
       <controlfield tag="008">960129s1970    iq            ||| | ara u</controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_2884249_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_2884249_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22     1i 4500</leader>
       <controlfield tag="001">2884249</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140811232247.0</controlfield>
       <controlfield tag="008">960131s1953    ua            ||| | ara u</controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_2884517_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_2884517_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22     1i 4500</leader>
       <controlfield tag="001">2884517</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140811232318.0</controlfield>
       <controlfield tag="008">960130m19639999sy            ||| | ara u</controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_2884930_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_2884930_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22     1i 4500</leader>
       <controlfield tag="001">2884930</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140811232412.0</controlfield>
       <controlfield tag="008">960129s1970    iq            ||| | ara u</controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_2885161_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_2885161_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22     1  4500</leader>
       <controlfield tag="001">2885161</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140811232438.0</controlfield>
       <controlfield tag="008">930305s1969    iq            000 0 ara  </controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_2885195_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_2885195_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22     1  4500</leader>
       <controlfield tag="001">2885195</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140811232440.0</controlfield>
       <controlfield tag="008">930223s1970    iq       b    000 0 ara  </controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_2885303_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_2885303_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22     1  4500</leader>
       <controlfield tag="001">2885303</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140811232450.0</controlfield>
       <controlfield tag="008">930223s1969    iq            000 0 ara  </controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_29702_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_29702_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22        4500</leader>
       <controlfield tag="001">29702</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20141022025817.0</controlfield>
       <controlfield tag="008">850327m19601962iq af         000 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_3285081_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_3285081_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22      a 4500</leader>
       <controlfield tag="001">3285081</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140807214637.0</controlfield>
       <controlfield tag="008">980730s1950    ua            000 0 arard</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_3334637_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_3334637_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     mam a22        4500</leader>
       <controlfield tag="001">3334637</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140806204502.0</controlfield>
       <controlfield tag="008">890112m19681969iq       w    000 0 ara d</controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_3447920_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_3447920_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22     4a 4500</leader>
       <controlfield tag="001">3447920</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140805200803.0</controlfield>
       <controlfield tag="008">990602r19251998ua       b    000 0 ara c</controlfield>
       <datafield tag="020" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_3637593_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_3637593_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22      a 4500</leader>
       <controlfield tag="001">3637593</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140803194120.0</controlfield>
       <controlfield tag="008">870507s1948    ua            000 0 arard</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_3644615_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_3644615_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22     1a 4500</leader>
       <controlfield tag="001">3644615</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140803195725.0</controlfield>
       <controlfield tag="008">960109s1957    iq            000 0 ara|d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_3750414_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_3750414_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22      i 4500</leader>
       <controlfield tag="001">3750414</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140802203256.0</controlfield>
       <controlfield tag="008">850321s1955    sy fh    b    001 0dara  </controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_3752114_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_3752114_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22        4500</leader>
       <controlfield tag="001">3752114</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140802203714.0</controlfield>
       <controlfield tag="008">890309q19601969sy            000 0 ara  </controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_3752809_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_3752809_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22        4500</leader>
       <controlfield tag="001">3752809</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140802203845.0</controlfield>
       <controlfield tag="008">801023m19491963ua            000 0 arar </controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_3753225_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_3753225_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22     1  4500</leader>
       <controlfield tag="001">3753225</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140802203942.0</controlfield>
       <controlfield tag="008">890331s1926    iq            000 0 ara d</controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_3759413_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_3759413_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22        4500</leader>
       <controlfield tag="001">3759413</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140802205901.0</controlfield>
       <controlfield tag="008">900507s1951    ua       b    000 0 ara  </controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_3760816_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_3760816_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22        4500</leader>
       <controlfield tag="001">3760816</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140802210210.0</controlfield>
       <controlfield tag="008">900912s1939    ua       b    000 0 arar </controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_3761021_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_3761021_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22        4500</leader>
       <controlfield tag="001">3761021</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140802210235.0</controlfield>
       <controlfield tag="008">910729s1951    ae a          000 0 ara  </controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_3763233_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_3763233_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22        4500</leader>
       <controlfield tag="001">3763233</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140802210740.0</controlfield>
       <controlfield tag="008">930507m19559999ua ab    b    000 0 ara d</controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_3763940_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_3763940_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22      a 4500</leader>
       <controlfield tag="001">3763940</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140802210910.0</controlfield>
       <controlfield tag="008">941117s1957    ae            001 0 arard</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_3771658_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_3771658_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22     1  4500</leader>
       <controlfield tag="001">3771658</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140802212721.0</controlfield>
       <controlfield tag="008">880825s1950    le            000 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_3771718_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_3771718_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22     1a 4500</leader>
       <controlfield tag="001">3771718</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140802212732.0</controlfield>
       <controlfield tag="008">871221s1937    ua            000 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_3771823_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_3771823_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22      a 4500</leader>
       <controlfield tag="001">3771823</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140802212749.0</controlfield>
       <controlfield tag="008">941014m19559999ua ab    b    000 0 arard</controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_3772036_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_3772036_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22      a 4500</leader>
       <controlfield tag="001">3772036</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140802212835.0</controlfield>
       <controlfield tag="008">921201s1951    ua bc    b    001 0darard</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_3772152_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_3772152_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22        4500</leader>
       <controlfield tag="001">3772152</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140802212849.0</controlfield>
       <controlfield tag="008">830118s1952    ua            000 0 arar </controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_3772874_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_3772874_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22      a 4500</leader>
       <controlfield tag="001">3772874</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140802213050.0</controlfield>
       <controlfield tag="008">941014s1949    ua a     b    001 0 arard</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_3780471_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_3780471_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22     1a 4500</leader>
       <controlfield tag="001">3780471</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140802215328.0</controlfield>
       <controlfield tag="008">000223s1954    iq            000 0 ara|d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_3955844_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_3955844_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22        4500</leader>
       <controlfield tag="001">3955844</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140731212836.0</controlfield>
       <controlfield tag="008">900227s1955    le            00  0 ara  </controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_3955851_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_3955851_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22        4500</leader>
       <controlfield tag="001">3955851</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140731212836.0</controlfield>
       <controlfield tag="008">870810m19451959le h     b    001 0carard</controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_4412231_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_4412231_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22     I  4500</leader>
       <controlfield tag="001">4412231</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140726184131.0</controlfield>
       <controlfield tag="008">780803s1952    ua            000 0 ara  </controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_4431308_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_4431308_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22     I  4500</leader>
       <controlfield tag="001">4431308</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140726193940.0</controlfield>
       <controlfield tag="008">890317s1952    ua       b    000 0 ara  </controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_4432760_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_4432760_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22     I  4500</leader>
       <controlfield tag="001">4432760</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140726194350.0</controlfield>
       <controlfield tag="008">850326s1939    tu       b    000 0 ara  </controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_4432772_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_4432772_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22     Ia 4500</leader>
       <controlfield tag="001">4432772</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140726194352.0</controlfield>
       <controlfield tag="008">880504s1957    sy            000 0 arard</controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_4432944_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_4432944_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22     I  4500</leader>
       <controlfield tag="001">4432944</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140726194421.0</controlfield>
       <controlfield tag="008">900427s1933    ua            000 0 ara c</controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_4437516_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_4437516_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22     L  4500</leader>
       <controlfield tag="001">4437516</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140726195416.0</controlfield>
       <controlfield tag="008">950505s1947    le            000 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_4460900_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_4460900_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22     K  4500</leader>
       <controlfield tag="001">4460900</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140726205423.0</controlfield>
       <controlfield tag="008">021030s1932    ua            000 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_4472539_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_4472539_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22     1i 4500</leader>
       <controlfield tag="001">4472539</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140726211741.0</controlfield>
       <controlfield tag="008">980727m19331935ua            000 0 arard</controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_4472641_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_4472641_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22     1a 4500</leader>
       <controlfield tag="001">4472641</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140726211755.0</controlfield>
       <controlfield tag="008">850630s1952    ua            000 0 araod</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_4515148_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_4515148_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22     I  4500</leader>
       <controlfield tag="001">4515148</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140725184921.0</controlfield>
       <controlfield tag="008">801002m19439999ua            000 0 ara  </controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_4715658_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_4715658_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22     1a 4500</leader>
       <controlfield tag="001">4715658</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140318223159.0</controlfield>
       <controlfield tag="008">940426q19601969iq       b    001 0 arar </controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_4722767_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_4722767_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22     1a 4500</leader>
       <controlfield tag="001">4722767</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140723193725.0</controlfield>
       <controlfield tag="008">890908m19481949ua h          000 0 araod</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_4739250_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_4739250_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22     K  4500</leader>
       <controlfield tag="001">4739250</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140723202401.0</controlfield>
       <controlfield tag="008">940302s1948    ua       b    000 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_4740767_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_4740767_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22     I  4500</leader>
       <controlfield tag="001">4740767</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140723202640.0</controlfield>
       <controlfield tag="008">850327s1939    le a     b    000 0 aras </controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_4744092_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_4744092_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22     K  4500</leader>
       <controlfield tag="001">4744092</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140723203247.0</controlfield>
       <controlfield tag="008">860923s1898    ua            000 0 arao </controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_4755497_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_4755497_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22     1a 4500</leader>
       <controlfield tag="001">4755497</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140723205636.0</controlfield>
       <controlfield tag="008">960919s1931    ua            000 0 araod</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_4853013_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_4853013_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22     K  4500</leader>
       <controlfield tag="001">4853013</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140722201730.0</controlfield>
       <controlfield tag="008">940302s1951    ua            000 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_4855214_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_4855214_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22     I  4500</leader>
       <controlfield tag="001">4855214</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140722202154.0</controlfield>
       <controlfield tag="008">851003m19549999ua       b    000 0 ara  </controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_4889711_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_4889711_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22      a 4500</leader>
       <controlfield tag="001">4889711</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140722213712.0</controlfield>
       <controlfield tag="008">910906s1940    ua            000 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_4889756_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_4889756_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22      a 4500</leader>
       <controlfield tag="001">4889756</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140722213717.0</controlfield>
       <controlfield tag="008">900801q19001999ua            000 0 arard</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_4905785_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_4905785_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22     I  4500</leader>
       <controlfield tag="001">4905785</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140721184257.0</controlfield>
       <controlfield tag="008">830314s1955    le            000 0 ara  </controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_4905786_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_4905786_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22     Ia 4500</leader>
       <controlfield tag="001">4905786</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140721184258.0</controlfield>
       <controlfield tag="008">900802s1955    ua            000 0 arar </controlfield>
       <datafield tag="010" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_4915152_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_4915152_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22      a 4500</leader>
       <controlfield tag="001">4915152</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140721191923.0</controlfield>
       <controlfield tag="008">990406q19601969iq       b    000 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">

--- a/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_5019427_marcxml.xml
+++ b/marcxml/cornell/oai.library.cornell.edu/nyu/2014-10-28_batch/cornell_5019427_marcxml.xml
@@ -3,7 +3,7 @@
    <record>
       <leader>     cam a22      a 4500</leader>
       <controlfield tag="001">5019427</controlfield>
-      <controlfield tag="003">COO</controlfield>
+      <controlfield tag="003">NIC</controlfield>
       <controlfield tag="005">20140720190605.0</controlfield>
       <controlfield tag="008">040304s1951    ua            000 0 ara d</controlfield>
       <datafield tag="035" ind1=" " ind2=" ">


### PR DESCRIPTION
Update records with ones containing Cornell's MARC identifier (NIC) in 003 field.
