### PR TITLE
add cornell_21783

### DIFF
--- a/marcxml/cornell/cornell_21783.xml
+++ b/marcxml/cornell/cornell_21783.xml
@@ -1,0 +1,96 @@
+   <record>
+      <leader>     cam a22      a 4500</leader>
+      <controlfield tag="001">21783</controlfield>
+      <controlfield tag="005">20130531095813.0</controlfield>
+      <controlfield tag="008">850308m19781980ir       b    001 0carar </controlfield>
+      <datafield tag="010" ind1=" " ind2=" ">
+         <subfield code="a">   82901242/NE/r842 </subfield>
+      </datafield>
+      <datafield tag="035" ind1=" " ind2=" ">
+         <subfield code="a">(CStRLIN)NYCX85B24143</subfield>
+      </datafield>
+      <datafield tag="035" ind1=" " ind2=" ">
+         <subfield code="a">(NIC)notisAAC2032</subfield>
+      </datafield>
+      <datafield tag="035" ind1=" " ind2=" ">
+         <subfield code="a">(OCoLC)10711000</subfield>
+      </datafield>
+      <datafield tag="035" ind1=" " ind2=" ">
+         <subfield code="a">21783</subfield>
+      </datafield>
+      <datafield tag="040" ind1=" " ind2=" ">
+         <subfield code="d">CStRLIN</subfield>
+         <subfield code="d">NIC</subfield>
+      </datafield>
+      <datafield tag="050" ind1="0" ind2=" ">
+         <subfield code="a">LAW</subfield>
+      </datafield>
+      <datafield tag="100" ind1="1" ind2=" ">
+         <subfield code="a">Ibn Qāḍī Shuhbah, Abū Bakr ibn Aḥmad,</subfield>
+         <subfield code="d">1377-1448.</subfield>
+      </datafield>
+      <datafield tag="245" ind1="1" ind2="0">
+         <subfield code="a">Ṭabaqāt al-Shāfiʻīyah /</subfield>
+         <subfield code="c">li-Abī Bakr ibn Aḥmad ibn Muḥammad ibn ʻUmar ibn Muḥammad, Taqī al-Dīn ibn Qāḍī Shubah al-Dimashqī ; iʻtaná bi-taṣḥīḥi wa-ʻallaqa ʻalayhi wa-rataba fahārisah al-Ḥāfiẓ ʻAbd al-ʻAlīm Khān.</subfield>
+      </datafield>
+      <datafield tag="250" ind1=" " ind2=" ">
+         <subfield code="a">al-Ṭabʻah 1.</subfield>
+      </datafield>
+      <datafield tag="260" ind1=" " ind2=" ">
+         <subfield code="a">Ḥaydarābād al-Dakkan, al-Hind :</subfield>
+         <subfield code="b">Maṭbaʻah Majlis Dāʾirat al-Maʻārif al-ʻUthmānīyah,</subfield>
+         <subfield code="c">1978-1980.</subfield>
+      </datafield>
+      <datafield tag="300" ind1=" " ind2=" ">
+         <subfield code="a">4 v. ;</subfield>
+         <subfield code="c">25 cm.</subfield>
+      </datafield>
+      <datafield tag="490" ind1="1" ind2=" ">
+         <subfield code="a">Maṭbūʻāt Dāʾirat al-Maʻārif al-ʻUthmānīyah. Silsilah al-jadīdah ;</subfield>
+         <subfield code="v">5/j/7</subfield>
+      </datafield>
+      <datafield tag="500" ind1=" " ind2=" ">
+         <subfield code="a">In Arabic.</subfield>
+      </datafield>
+      <datafield tag="500" ind1=" " ind2=" ">
+         <subfield code="a">Title on added t.p.: Tabaqāt ash-Shāfiʻiya. (Dai̓ratul̓-Maʻarifiʻl-Osmania publications. New series ; no. V/C/VII)</subfield>
+      </datafield>
+      <datafield tag="504" ind1=" " ind2=" ">
+         <subfield code="a">Includes bibliographical references and index.</subfield>
+      </datafield>
+      <datafield tag="650" ind1=" " ind2="0">
+         <subfield code="a">Shafiites</subfield>
+         <subfield code="x">Biography</subfield>
+         <subfield code="x">Early works to 1800.</subfield>
+      </datafield>
+      <datafield tag="700" ind1="1" ind2=" ">
+         <subfield code="a">Khān, al-Ḥāfiẓ ʻAbd al-ʻAlīm.</subfield>
+      </datafield>
+      <datafield tag="740" ind1="0" ind2=" ">
+         <subfield code="a">Ṭabaqāt ash-Shāfiʻīya.</subfield>
+      </datafield>
+      <datafield tag="830" ind1=" " ind2="0">
+         <subfield code="a">Silsilah al-jadīdah min maṭbūʻāt Dāʾirat al-Maʻārif al-ʻUthmānīyah.</subfield>
+         <subfield code="v">5/j/7.</subfield>
+      </datafield>
+      <datafield tag="905" ind1=" " ind2=" ">
+         <subfield code="a">19951128120000.0</subfield>
+      </datafield>
+      <datafield tag="948" ind1="2" ind2=" ">
+         <subfield code="a">20090227</subfield>
+         <subfield code="b">m</subfield>
+         <subfield code="d">batch</subfield>
+         <subfield code="e">lts</subfield>
+         <subfield code="x">del9xx</subfield>
+      </datafield>
+      <datafield tag="950" ind1=" " ind2=" ">
+         <subfield code="l">OLIN</subfield>
+         <subfield code="a">BP166.14.S4</subfield>
+         <subfield code="b">I13 1978</subfield>
+         <subfield code="h">04/09/85 C ?40:\Slocum\</subfield>
+      </datafield>
+      <datafield tag="995" ind1=" " ind2=" ">
+         <subfield code="a">Hivolm</subfield>
+         <subfield code="d">20090227</subfield>
+      </datafield>
+   </record>


### PR DESCRIPTION
This MARCXML record was used for the pilot.  It was last received
via e-mail from the ACO PM on 2014-11-12 and the item does not
appear on the Cornell website used to pull marcxml files:
http://oai.library.cornell.edu/nyu