### PR TITLE
Add function to pad 008 to 40 chars

### DIFF
--- a/bin/aco-1-xml2mrc-oclc-nums.py
+++ b/bin/aco-1-xml2mrc-oclc-nums.py
@@ -51,6 +51,7 @@ for filename in os.listdir(marcxml_dir):
 		if file_path[-3:]=='xml':
 			marc_xml_array = pymarc.parse_xml_to_array(file_path)
 			for rec in marc_xml_array:
+				rec = aco_functions.pad_008(rec)
 				marcRecsOut_orig_recs.write(rec)
 marcRecsOut_orig_recs.close()
 

--- a/bin/aco_functions.py
+++ b/bin/aco_functions.py
@@ -10,6 +10,26 @@ from copy import deepcopy
 import aco_globals
 
 ######################################################################
+##  Method:  pad_008() - for NYU records, pads the 008 field to 40 chars
+##		fixing when blanks in bytes 38 and/or 39 are deleted when
+##		exported out of Aleph using URL template
+######################################################################
+def pad_008(rec):
+	rec_008_val = rec.get_fields('008')[0].value()
+	if len(rec_008_val) < 40:
+		pad_008_val = rec_008_val.ljust(40)
+		
+		# delete the existing 008 field from the original record
+		rec.remove_field(rec.get_fields('008')[0])
+		
+		# add new 008 field padded to 40 chars to the original record
+		new_008 = Field(tag='008', data=pad_008_val)
+		rec.add_ordered_field(new_008)
+		
+	return rec
+		
+
+######################################################################
 ##  Method:  strip_number()
 ######################################################################
 def strip_number(oclc_subfield):


### PR DESCRIPTION
This new function is to fix 008 fields for NYU MARCXML records exported out of Aleph using the URL template:
http://aleph.library.nyu.edu/X?op=publish_avail&doc_num=<BSN>&library=nyu01
The final bytes 38 and/or 39 get deleted from the 008 field if they are blanks in Aleph, resulting in the 008 field being too short and failing validation rules.  The length of the 008 field should be 40 characters, so this function pads the field with spaces at the end if it is less than 40 chars.