### PR TITLE
Remove 999 subfield e (error types) from output message

### DIFF
--- a/bin/aco_functions.py
+++ b/bin/aco_functions.py
@@ -133,7 +133,11 @@ def process_001_003_fields(rec_orig, rec, oclc_nums_bsns_all):
 		for rec_999 in rec_999s:
 			msg += '   '+rec_999+'\n'
 	elif len(rec_999s) == 1:
-		msg += 'Record 999:  '+rec_999s[0].value()+'\n'
+		new_999 = deepcopy(rec_999s[0])
+		for new_999e in new_999.get_subfields('e'):
+			# delete any existing subfield $e in the new 999 field
+			new_999.delete_subfield('e')
+		msg += 'Record 999:  '+new_999.value()+'\n'
 	
 	return (rec_orig, rec, oclc_id, inst_id, oclc_match, msg)
 


### PR DESCRIPTION
Added code to delete existing 999-e subfields from updated records so that the error types don't appear in the output messages for the next round of analysis, which was causing all the updated records to re-appear as errors when they're not.