### PR TITLE
Remove extra OCLC num in 035s for NjP_2758645_marcxml.xml

### DIFF
--- a/work/NjP/NjP_20150903/marcxml_in/NjP_2758645_marcxml.xml
+++ b/work/NjP/NjP_20150903/marcxml_in/NjP_2758645_marcxml.xml
@@ -11,9 +11,6 @@
          <marc:subfield code="2">local</marc:subfield>
       </marc:datafield>
       <marc:datafield tag="035" ind1=" " ind2=" ">
-         <marc:subfield code="a">(OCoLC)ocn880636008</marc:subfield>
-      </marc:datafield>
-      <marc:datafield tag="035" ind1=" " ind2=" ">
          <marc:subfield code="a">(OCoLC)ocm21954230</marc:subfield>
       </marc:datafield>
       <marc:datafield tag="035" ind1=" " ind2=" ">
@@ -29,9 +26,6 @@
       </marc:datafield>
       <marc:datafield tag="066" ind1=" " ind2=" ">
          <marc:subfield code="c">(3</marc:subfield>
-      </marc:datafield>
-      <marc:datafield tag="035" ind1=" " ind2=" ">
-         <marc:subfield code="a">(OCoLC)880636008</marc:subfield>
       </marc:datafield>
       <marc:datafield tag="050" ind1="0" ind2=" ">
          <marc:subfield code="a">PJ6171</marc:subfield>


### PR DESCRIPTION
marcxml_in record - NjP_2758645_marcxml.xml - had two 035 fields for an OCLC number in addition to the better OCLC record number listed in a third 035 field.  I removed the two 035s containing the un-necessary OCLC number which was causing duplicate records to be pulled from Connexion.