### PR TITLE
Remove extra OCLC num in 079 for NjP_2758645_marcxml.xml

### DIFF
--- a/work/NjP/NjP_20150903/marcxml_in/NjP_2758645_marcxml.xml
+++ b/work/NjP/NjP_20150903/marcxml_in/NjP_2758645_marcxml.xml
@@ -31,9 +31,6 @@
          <marc:subfield code="a">PJ6171</marc:subfield>
          <marc:subfield code="b">.Z3 1970 (Orien Arab)</marc:subfield>
       </marc:datafield>
-      <marc:datafield tag="079" ind1=" " ind2=" ">
-         <marc:subfield code="a">ocn122996757</marc:subfield>
-      </marc:datafield>
       <marc:datafield tag="049" ind1=" " ind2=" ">
          <marc:subfield code="a">PULL</marc:subfield>
       </marc:datafield>


### PR DESCRIPTION
This record - NjP_2758645_marcxml.xml - had yet a 3rd OCLC number in an 079 field.  I removed that field so that the record would not get processed twice, and would only process the good OCLC record number in the final 035 field.