### PR TITLE
update columbia/batch_005 bsn-se-map.csv

### DIFF
--- a/work/NNC/NNC_20150615/bsn-se-map.csv
+++ b/work/NNC/NNC_20150615/bsn-se-map.csv
@@ -21,7 +21,7 @@
 2957918,columbia_aco000966
 2872111,columbia_aco000896
 31674,columbia_aco000920
-2872174,columbia_aco000927
+2872174,columbia_aco000928
 2958649,columbia_aco000804
 3073306,columbia_aco000929
 2959309,columbia_aco000883
@@ -50,7 +50,7 @@
 2960352,columbia_aco000974
 859198,columbia_aco000924
 887691,columbia_aco000947:v. 1|columbia_aco000948:v. 2|columbia_aco000949:v. 3
-2959276,columbia_aco000928
+2959276,columbia_aco000927
 867159,columbia_aco000834
 2761524,columbia_aco000988
 2964662,columbia_aco000857


### PR DESCRIPTION
The DMD for columbia_aco000927 and columbia_aco000927 was swapped.
This commit corrects the mapping.