### PR TITLE
Add criteria in unl_880s function to ignore 880s for 5XX fields

### DIFF
--- a/bin/aco_functions.py
+++ b/bin/aco_functions.py
@@ -198,7 +198,7 @@ def check_for_unlinked_880s(rec):
 			msg += 'ERROR-MISC: There are either zero or multiple subfield $6s in this 880: '+rec_880+'\n'
 		else:
 			rec_880_6 = rec_880_6s[0]
-			if rec_880_6[4:6]=='00':
+			if rec_880_6[4:6]=='00' and not rec_880_6[0:1]=='5':
 				unlinked_880s_exist = True
 				msg_unlnkd_880_6s += '   880 $6 '+rec_880_6+' - '
 				rec_880_pf = rec_880_6[0:3]				# get the corresponding parallel MARC field tag


### PR DESCRIPTION
This criteria is being added to accommodate for AUB/LeBAU records which contain unlinked 880 script fields for 5XX notes, where there's no counterpart field.