### PR TITLE
remove extra space from LeBAU_20151212/marcxml_out records

### DIFF
--- a/work/LeBAU/LeBAU_20151212/marcxml_out/LeBAU_b12366031_marcxml.xml
+++ b/work/LeBAU/LeBAU_20151212/marcxml_out/LeBAU_b12366031_marcxml.xml
@@ -1,301 +1,149 @@
-<?xml version="1.0" encoding="utf-8"?>
-<record xmlns="http://www.loc.gov/MARC21/slim" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd">
-	<leader>
-		02743nam a2200433   4500
-	</leader>
-	<controlfield tag="001">
-		b12366031
-	</controlfield>
-	<controlfield tag="003">
-		LeBAU
-	</controlfield>
-	<controlfield tag="006">
-		m        d        
-	</controlfield>
-	<controlfield tag="007">
-		cr cn |||m|||a
-	</controlfield>
-	<controlfield tag="008">
-		160203s1901    ua      o     ||0 0 ara d
-	</controlfield>
-	<datafield ind1=" " ind2=" " tag="040">
-		<subfield code="a">
-			NNU
-		</subfield>
-		<subfield code="b">
-			ara
-		</subfield>
-		<subfield code="e">
-			rda
-		</subfield>
-		<subfield code="c">
-			NNU
-		</subfield>
-	</datafield>
-	<datafield ind1="0" ind2="4" tag="082">
-		<subfield code="a">
-			297.38
-		</subfield>
-		<subfield code="2">
-			20
-		</subfield>
-	</datafield>
-	<datafield ind1="1" ind2=" " tag="100">
-		<subfield code="6">
-			880-01
-		</subfield>
-		<subfield code="a">
-			Ibn Qudāmah al-Maqdisī, Muḥammad ibn Aḥmad,
-		</subfield>
-		<subfield code="d">
-			approximately 1306-1344,
-		</subfield>
-		<subfield code="e">
-			author.
-		</subfield>
-	</datafield>
-	<datafield ind1="1" ind2="0" tag="245">
-		<subfield code="6">
-			880-02
-		</subfield>
-		<subfield code="a">
-			Kitāb al-ṣārim al-munkī fī al-radd ʻalá al-Subkī /
-		</subfield>
-		<subfield code="c">
-			ta’līf al-imām al-‘allāmah al-ḥāfiẓ al-Muḥaqqiq Abī ‘Abd Allāh Muḥammad ibn Aḥmad ibn ‘Abd al-Hādī al-Ḥanbalī al-Maqdisī.
-		</subfield>
-	</datafield>
-	<datafield ind1="3" ind2="0" tag="246">
-		<subfield code="6">
-			880-03
-		</subfield>
-		<subfield code="a">
-			al-Ṣārim al-munkī fī al-radd ʻalá al-Subkī
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2="1" tag="264">
-		<subfield code="6">
-			880-04
-		</subfield>
-		<subfield code="a">
-			al-Qāhirah, [Miṣr] :
-		</subfield>
-		<subfield code="b">
-			al-Maṭbaʻah al-khayrīyah,
-		</subfield>
-		<subfield code="c">
-			1319 H. [1901? M.]
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2=" " tag="300">
-		<subfield code="6">
-			880-05
-		</subfield>
-		<subfield code="a">
-			online resource (339 pages)
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2=" " tag="336">
-		<subfield code="a">
-			text
-		</subfield>
-		<subfield code="2">
-			rdacontent
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2=" " tag="337">
-		<subfield code="a">
-			computer
-		</subfield>
-		<subfield code="2">
-			rdamedia
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2=" " tag="338">
-		<subfield code="a">
-			online resource
-		</subfield>
-		<subfield code="2">
-			rdacarrier
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2=" " tag="500">
-		<subfield code="a">
-			Part of the Arabic Collections Online (ACO) project, contributed by American University of Beirut's Jafet Memorial Library.
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2=" " tag="533">
-		<subfield code="a">
-			Electronic reproduction.
-		</subfield>
-		<subfield code="b">
-			New York, N.Y. :
-		</subfield>
-		<subfield code="c">
-			New York University,
-		</subfield>
-		<subfield code="d">
-			2016.
-		</subfield>
-		<subfield code="5">
-			NNU
-		</subfield>
-	</datafield>
-	<datafield ind1="1" ind2="4" tag="600">
-		<subfield code="a">
-			السبكي، تقي الدين علي بن عبدالكافي.
-		</subfield>
-		<subfield code="t">
-			شفاء السقام في زيارة خير الأنام.
-		</subfield>
-	</datafield>
-	<datafield ind1="1" ind2="0" tag="600">
-		<subfield code="a">
-			Subkī, Taqī al-Dīn ʻAlī ibn ʻAbd al-Kāfī,
-		</subfield>
-		<subfield code="d">
-			1284-1355.
-		</subfield>
-		<subfield code="t">
-			Shifāʼ al-saqām fī ziyārat Khayr al-Anām.
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2="4" tag="650">
-		<subfield code="a">
-			المزارات الاسلامية.
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2="4" tag="650">
-		<subfield code="a">
-			الحجاج والحج الاسلامي.
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2="0" tag="650">
-		<subfield code="a">
-			Islamic shrines.
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2="0" tag="650">
-		<subfield code="a">
-			Muslim pilgrims and pilgrimages.
-		</subfield>
-	</datafield>
-	<datafield ind1="2" ind2=" " tag="710">
-		<subfield code="a">
-			Jafet Memorial Library.
-		</subfield>
-	</datafield>
-	<datafield ind1="0" ind2=" " tag="730">
-		<subfield code="a">
-			Arabic Collections Online.
-		</subfield>
-	</datafield>
-	<datafield ind1="0" ind2="8" tag="776">
-		<subfield code="i">
-			Print version:
-		</subfield>
-		<subfield code="a">
-			Ibn Qudāmah al-Maqdisī, Muḥammad ibn Aḥmad, approximately 1306-1344, author.
-		</subfield>
-		<subfield code="t">
-			Kitāb al-ṣārim al-munkī fī al-radd ʻalá al-Subkī
-		</subfield>
-		<subfield code="w">
-			(LeBAU)b12366031
-		</subfield>
-	</datafield>
-	<datafield ind1="4" ind2="0" tag="856">
-		<subfield code="u">
-			http://hdl.handle.net/2333.1/8pk0p5vx
-		</subfield>
-	</datafield>
-	<datafield ind1="1" ind2=" " tag="880">
-		<subfield code="6">
-			100-01/(3/r
-		</subfield>
-		<subfield code="a">
-			إبن عبد الهادي، أبو عبد الله محمد بن أحمد،
-		</subfield>
-		<subfield code="d">
-			1305-1343،
-		</subfield>
-		<subfield code="e">
-			مؤلف. 
-		</subfield>
-		<subfield code="4">
-			aut.
-		</subfield>
-	</datafield>
-	<datafield ind1="1" ind2="0" tag="880">
-		<subfield code="6">
-			245-02/(3/r
-		</subfield>
-		<subfield code="a">
-			كتاب الصارم المنكي في الرد على السبكي /
-		</subfield>
-		<subfield code="c">
-			تأليف سيدنا الإمام العلامة الحافظ المحقق أبي عبد الله محمد بن أحمد بن عبد الهادي الحنبلي المقدسي.
-		</subfield>
-	</datafield>
-	<datafield ind1="3" ind2="0" tag="880">
-		<subfield code="6">
-			246-03/(3/r
-		</subfield>
-		<subfield code="a">
-			الصارم المنكي في الرد على السبكي
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2="1" tag="880">
-		<subfield code="6">
-			264-04/(3/r
-		</subfield>
-		<subfield code="a">
-			القاهرة [مصر] :
-		</subfield>
-		<subfield code="b">
-			المطبعة الخيرية،
-		</subfield>
-		<subfield code="c">
-			1319هـ. [1901؟ م.]
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2=" " tag="880">
-		<subfield code="6">
-			300-05/(3/r
-		</subfield>
-		<subfield code="a">
-			339 صفحة ؛
-		</subfield>
-		<subfield code="c">
-			18 سم
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2=" " tag="959">
-		<subfield code="a">
-			NNU
-		</subfield>
-		<subfield code="b">
-			WEB
-		</subfield>
-		<subfield code="c">
-			GENI
-		</subfield>
-		<subfield code="t">
-			0
-		</subfield>
-		<subfield code="m">
-			Electronic access
-		</subfield>
-		<subfield code="s">
-			01
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2=" " tag="999">
-		<subfield code="i">
-			LeBAU_b12366031
-		</subfield>
-		<subfield code="s">
-			aub_aco000002
-		</subfield>
-	</datafield>
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<collection xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.loc.gov/MARC21/slim
+        http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd"
+    xmlns="http://www.loc.gov/MARC21/slim">
+<record>
+  <leader>00217cam a2200397 i 4500</leader>
+  <controlfield tag="001">b12366031</controlfield>
+  <controlfield tag="003">LeBAU</controlfield>
+  <controlfield tag="005">20130916</controlfield>
+  <controlfield tag="008">970225s1901    ua            ||0 0 ara d</controlfield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">ocn784272205</subfield>
+  </datafield>
+  <datafield tag="040" ind1=" " ind2=" ">
+    <subfield code="a">LEAUB</subfield>
+    <subfield code="b">ara</subfield>
+    <subfield code="e">rda</subfield>
+    <subfield code="c">LEAUB</subfield>
+    <subfield code="d">LEAUB</subfield>
+  </datafield>
+  <datafield tag="082" ind1="0" ind2="4">
+    <subfield code="a">297.38</subfield>
+    <subfield code="2">20</subfield>
+  </datafield>
+  <datafield tag="100" ind1="1" ind2=" ">
+    <subfield code="6">880-01</subfield>
+    <subfield code="a">Ibn Qudāmah al-Maqdisī, Muḥammad ibn Aḥmad,</subfield>
+    <subfield code="d">approximately 1306-1344,</subfield>
+    <subfield code="e">author.</subfield>
+  </datafield>
+  <datafield tag="245" ind1="1" ind2="0">
+    <subfield code="6">880-02</subfield>
+    <subfield code="a">Kitāb al-ṣārim al-munkī fī al-radd ʻalá al-Subkī /</subfield>
+    <subfield code="c">ta’līf al-imām al-‘allāmah al-ḥāfiẓ al-Muḥaqqiq Abī ‘Abd Allāh Muḥammad ibn Aḥmad ibn ‘Abd al-Hādī al-Ḥanbalī al-Maqdisī.</subfield>
+  </datafield>
+  <datafield tag="246" ind1="3" ind2="0">
+    <subfield code="6">880-03</subfield>
+    <subfield code="a">al-Ṣārim al-munkī fī al-radd ʻalá al-Subkī</subfield>
+  </datafield>
+  <datafield tag="264" ind1=" " ind2="1">
+    <subfield code="6">880-04</subfield>
+    <subfield code="a">al-Qāhirah, [Miṣr] :</subfield>
+    <subfield code="b">al-Maṭbaʻah al-khayrīyah,</subfield>
+    <subfield code="c">1319 H. [1901? M.]</subfield>
+  </datafield>
+  <datafield tag="300" ind1=" " ind2=" ">
+    <subfield code="6">880-05</subfield>
+    <subfield code="a">339 pages ;</subfield>
+    <subfield code="c">18 cm</subfield>
+  </datafield>
+  <datafield tag="336" ind1=" " ind2=" ">
+    <subfield code="a">text</subfield>
+    <subfield code="b">txt</subfield>
+    <subfield code="2">rdacontent</subfield>
+  </datafield>
+  <datafield tag="337" ind1=" " ind2=" ">
+    <subfield code="a">unmediated</subfield>
+    <subfield code="b">n</subfield>
+    <subfield code="2">rdamedia</subfield>
+  </datafield>
+  <datafield tag="338" ind1=" " ind2=" ">
+    <subfield code="a">volume</subfield>
+    <subfield code="b">nc</subfield>
+    <subfield code="2">rdacarrier</subfield>
+  </datafield>
+  <datafield tag="600" ind1="1" ind2="4">
+    <subfield code="a">السبكي، تقي الدين علي بن عبدالكافي.</subfield>
+    <subfield code="t">شفاء السقام في زيارة خير الأنام.</subfield>
+  </datafield>
+  <datafield tag="600" ind1="1" ind2="0">
+    <subfield code="a">Subkī, Taqī al-Dīn ʻAlī ibn ʻAbd al-Kāfī,</subfield>
+    <subfield code="d">1284-1355.</subfield>
+    <subfield code="t">Shifāʼ al-saqām fī ziyārat Khayr al-Anām.</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="4">
+    <subfield code="a">المزارات الاسلامية.</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="4">
+    <subfield code="a">الحجاج والحج الاسلامي.</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">Islamic shrines.</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">Muslim pilgrims and pilgrimages.</subfield>
+  </datafield>
+  <datafield tag="852" ind1=" " ind2=" ">
+    <subfield code="a">Jafet Library</subfield>
+    <subfield code="e">American University of Beirut, Bliss Street , Beirut, Lebanon.</subfield>
+  </datafield>
+  <datafield tag="880" ind1="1" ind2=" ">
+    <subfield code="6">100-01/(3/r</subfield>
+    <subfield code="a">إبن عبد الهادي، أبو عبد الله محمد بن أحمد،</subfield>
+    <subfield code="d">1305-1343،</subfield>
+    <subfield code="e">مؤلف. </subfield>
+    <subfield code="4">aut.</subfield>
+  </datafield>
+  <datafield tag="880" ind1="1" ind2="0">
+    <subfield code="6">245-02/(3/r</subfield>
+    <subfield code="a">كتاب الصارم المنكي في الرد على السبكي /</subfield>
+    <subfield code="c">تأليف سيدنا الإمام العلامة الحافظ المحقق أبي عبد الله محمد بن أحمد بن عبد الهادي الحنبلي المقدسي.</subfield>
+  </datafield>
+  <datafield tag="880" ind1="3" ind2="0">
+    <subfield code="6">246-03/(3/r</subfield>
+    <subfield code="a">الصارم المنكي في الرد على السبكي</subfield>
+  </datafield>
+  <datafield tag="880" ind1=" " ind2="1">
+    <subfield code="6">264-04/(3/r</subfield>
+    <subfield code="a">القاهرة [مصر] :</subfield>
+    <subfield code="b">المطبعة الخيرية،</subfield>
+    <subfield code="c">1319هـ. [1901؟ م.]</subfield>
+  </datafield>
+  <datafield tag="880" ind1=" " ind2=" ">
+    <subfield code="6">300-05/(3/r</subfield>
+    <subfield code="a">339 صفحة ؛</subfield>
+    <subfield code="c">18 سم</subfield>
+  </datafield>
+  <datafield tag="907" ind1=" " ind2=" ">
+    <subfield code="a">.b12366031</subfield>
+    <subfield code="b">15-10-15</subfield>
+    <subfield code="c">11-05-24</subfield>
+  </datafield>
+  <datafield tag="907" ind1=" " ind2=" ">
+    <subfield code="a">.b12366031</subfield>
+    <subfield code="b">11-10-11</subfield>
+    <subfield code="c">11-05-24</subfield>
+  </datafield>
+  <datafield tag="945" ind1=" " ind2=" ">
+    <subfield code="f">J</subfield>
+    <subfield code="a">297.38:I247saA:c.1</subfield>
+    <subfield code="g">1</subfield>
+    <subfield code="i">01008434</subfield>
+    <subfield code="j">.i12815457</subfield>
+    <subfield code="l">u0503</subfield>
+  </datafield>
+  <datafield tag="998" ind1=" " ind2=" ">
+    <subfield code="a">u05</subfield>
+    <subfield code="b">97-02-25</subfield>
+    <subfield code="c">m</subfield>
+    <subfield code="d">a</subfield>
+    <subfield code="e">-</subfield>
+    <subfield code="f">ara</subfield>
+    <subfield code="g">ua </subfield>
+    <subfield code="h">0</subfield>
+    <subfield code="i">1</subfield>
+  </datafield>
 </record>
+</collection>

--- a/work/LeBAU/LeBAU_20151212/marcxml_out/LeBAU_b12377740_marcxml.xml
+++ b/work/LeBAU/LeBAU_20151212/marcxml_out/LeBAU_b12377740_marcxml.xml
@@ -1,390 +1,239 @@
-<?xml version="1.0" encoding="utf-8"?>
-<record xmlns="http://www.loc.gov/MARC21/slim" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd">
-	<leader>
-		05501nam a2200517   4500
-	</leader>
-	<controlfield tag="001">
-		b12377740
-	</controlfield>
-	<controlfield tag="003">
-		LeBAU
-	</controlfield>
-	<controlfield tag="006">
-		m        d        
-	</controlfield>
-	<controlfield tag="007">
-		cr cn |||m|||a
-	</controlfield>
-	<controlfield tag="008">
-		160203m19061927ua      o     ||0 0 ara d
-	</controlfield>
-	<datafield ind1=" " ind2=" " tag="040">
-		<subfield code="a">
-			NNU
-		</subfield>
-		<subfield code="b">
-			ara
-		</subfield>
-		<subfield code="e">
-			rda
-		</subfield>
-		<subfield code="c">
-			NNU
-		</subfield>
-	</datafield>
-	<datafield ind1="0" ind2="4" tag="082">
-		<subfield code="a">
-			297.207
-		</subfield>
-		<subfield code="2">
-			20
-		</subfield>
-	</datafield>
-	<datafield ind1="0" ind2=" " tag="100">
-		<subfield code="6">
-			880-01
-		</subfield>
-		<subfield code="a">
-			Muḥammad Rashīd Riḍā,
-		</subfield>
-		<subfield code="d">
-			1865-1935،
-		</subfield>
-		<subfield code="e">
-			author.
-		</subfield>
-	</datafield>
-	<datafield ind1="1" ind2="0" tag="240">
-		<subfield code="6">
-			880-02
-		</subfield>
-		<subfield code="a">
-			Qur’an. tafāsīr
-		</subfield>
-	</datafield>
-	<datafield ind1="1" ind2="0" tag="245">
-		<subfield code="6">
-			880-03
-		</subfield>
-		<subfield code="a">
-			Tafsīr al-Qurʼān al-hakīm al-mushtahir bi-ism Tafsīr al-Manār /
-		</subfield>
-		<subfield code="c">
-			ta’līf al-Sayyid Muḥammad Rashīd Riḍā.
-		</subfield>
-	</datafield>
-	<datafield ind1="3" ind2="0" tag="246">
-		<subfield code="6">
-			880-04
-		</subfield>
-		<subfield code="a">
-			Tafsīr al-Manār
-		</subfield>
-	</datafield>
-	<datafield ind1="1" ind2=" " tag="246">
-		<subfield code="6">
-			880-05
-		</subfield>
-		<subfield code="i">
-			Subtitle on volume 2:
-		</subfield>
-		<subfield code="a">
-			Tafsīr salafī atharī madanī ‘aṣrī irshādī ijtimā‘ī siyāsī
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2=" " tag="250">
-		<subfield code="6">
-			880-06
-		</subfield>
-		<subfield code="a">
-			First edition
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2="1" tag="264">
-		<subfield code="6">
-			880-07
-		</subfield>
-		<subfield code="a">
-			Miṣr :
-		</subfield>
-		<subfield code="b">
-			Maṭbaʻat al-Manār,
-		</subfield>
-		<subfield code="c">
-			1324-1346 H., [1906-1927? M.]
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2=" " tag="300">
-		<subfield code="6">
-			880-08
-		</subfield>
-		<subfield code="a">
-			online resource (8 volumes)
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2=" " tag="336">
-		<subfield code="a">
-			text
-		</subfield>
-		<subfield code="2">
-			rdacontent
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2=" " tag="337">
-		<subfield code="a">
-			computer
-		</subfield>
-		<subfield code="2">
-			rdamedia
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2=" " tag="338">
-		<subfield code="a">
-			online resource
-		</subfield>
-		<subfield code="2">
-			rdacarrier
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2=" " tag="500">
-		<subfield code="a">
-			&quot;هذا هو التفسير الوحيد الجامع بين صحيح المأثور وصريح المعقول الذي يبين حكم التشريع وسنن الله في الإنسان، وكون القرآن هداية للبشر في كل زمان ومكان، ويوازن بين هدايته وما عليه المسلمون في هذا العصر وقد أعرضوا عنها، وما كان عليه سلفهم المعتصمين بحبلها، مراعي فيه السهولة في التعبير، مجتنبا مزج الكلام بإصطلاحات العلوم والفنون بحيث يفهمه العامة ولا يستغني عنه الخاصة، وهذه هي الطريقة التي جرى عليها في دروسه في الأزهر حكيم الإسلام الأستاذ الإمام الشيخ محمد عبده.&quot;--صفحة العنوان.
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2=" " tag="500">
-		<subfield code="a">
-			Part of the Arabic Collections Online (ACO) project, contributed by American University of Beirut's Jafet Memorial Library.
-		</subfield>
-	</datafield>
-	<datafield ind1="0" ind2=" " tag="505">
-		<subfield code="a">
-			تفسير القرآن الحكيم المشتهر بإسم تفسير المنار: الجزء الثاني. وفيه خلاصة ما قاله الأستاذ الإمام في دروسه بالجامع الأزهر وقد قرأ أكثر من نصفه قبل طبعه وبعده --الجزء الثالث. أوله &quot;تلك الرسائل&quot; وفيه صفوة ما قاله الأستاذ الإمام --الجزء الرابع. أوله &quot;كل الطعام&quot; وفيه صفوة ما قاله الأستاذ الإمام في دروسه وقد إعتمدنا بعدد الآيات فيه على المصحف المطبوع في ألمانيا وفرقنا بينهما بنقطتين --الجزء الخامس. أوله &quot;المحصنات من النساء&quot; وفيه صفوة ما قاله الأستاذ الإمام في دروسه في الأزهر، وقد إعتمدنا بعدد الآيات فيه على المصحف المطبوع في الآستانة والمصحف المطبوع في ألمانيا وفرقنا بينهما بنقطتين --الجزء السادس. أوله &quot;لا يحب الله الجهر بالسوء&quot; وقد إعتمدنا بعدد الآيات فيه على المصحف المطبوع في الآستانة والمصحف المطبوع في ألمانيا وفرقنا بينهما بنقطتين --الجزء السابع. أوله &quot;لتجدن أشد الناس عداوة&quot; وقد إعتمدنا بعدد الآيات فيه على المصحف المطبوع في الآستانة والمصحف المطبوع في ألمانيا وفرقنا بينهما بنقطتين --الجزء الثامن. أوله &quot;ولو أننا نزلنا إليهم الملائكة&quot; وقد إعتمدنا بعدد الآيات فيه على المصحف المطبوع الآستانة والمصحف المطبوع في ألمانيا وفرقنا بينهما بنقطتين.
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2=" " tag="533">
-		<subfield code="a">
-			Electronic reproduction.
-		</subfield>
-		<subfield code="b">
-			New York, N.Y. :
-		</subfield>
-		<subfield code="c">
-			New York University,
-		</subfield>
-		<subfield code="d">
-			2016.
-		</subfield>
-		<subfield code="5">
-			NNU
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2=" " tag="588">
-		<subfield code="a">
-			الوصف يستند إلى الجزء الأول.
-		</subfield>
-	</datafield>
-	<datafield ind1="0" ind2="4" tag="630">
-		<subfield code="a">
-			قرآن
-		</subfield>
-		<subfield code="x">
-			تفسير وتأويل.
-		</subfield>
-	</datafield>
-	<datafield ind1="0" ind2="0" tag="630">
-		<subfield code="a">
-			Qur'an
-		</subfield>
-		<subfield code="x">
-			Hermeneutics.
-		</subfield>
-	</datafield>
-	<datafield ind1="1" ind2=" " tag="700">
-		<subfield code="6">
-			880-09
-		</subfield>
-		<subfield code="a">
-			ʻAbduh, Muḥammad,
-		</subfield>
-		<subfield code="d">
-			1849-1905,
-		</subfield>
-		<subfield code="e">
-			author.
-		</subfield>
-	</datafield>
-	<datafield ind1="2" ind2=" " tag="710">
-		<subfield code="a">
-			Jafet Memorial Library.
-		</subfield>
-	</datafield>
-	<datafield ind1="0" ind2=" " tag="730">
-		<subfield code="a">
-			Arabic Collections Online.
-		</subfield>
-	</datafield>
-	<datafield ind1="0" ind2="8" tag="776">
-		<subfield code="i">
-			Print version:
-		</subfield>
-		<subfield code="a">
-			Muḥammad Rashīd Riḍā, 1865-1935، author.
-		</subfield>
-		<subfield code="t">
-			Tafsīr al-Qurʼān al-hakīm al-mushtahir bi-ism Tafsīr al-Manār
-		</subfield>
-		<subfield code="w">
-			(LeBAU)b12377740
-		</subfield>
-	</datafield>
-	<datafield ind1="4" ind2="0" tag="856">
-		<subfield code="u">
-			http://hdl.handle.net/2333.1/4xgxd5cx
-		</subfield>
-	</datafield>
-	<datafield ind1="0" ind2=" " tag="880">
-		<subfield code="6">
-			100-01/(3/r
-		</subfield>
-		<subfield code="a">
-			محمد رشيد رضا،
-		</subfield>
-		<subfield code="e">
-			مؤلف. 
-		</subfield>
-		<subfield code="4">
-			aut.
-		</subfield>
-	</datafield>
-	<datafield ind1="1" ind2="0" tag="880">
-		<subfield code="6">
-			240-02/(3/r
-		</subfield>
-		<subfield code="a">
-			قرآن. تفاسير
-		</subfield>
-	</datafield>
-	<datafield ind1="1" ind2="0" tag="880">
-		<subfield code="6">
-			245-03/(3/r
-		</subfield>
-		<subfield code="a">
-			تفسير القرآن الحكيم المشتهر بإسم تفسير المنار /
-		</subfield>
-		<subfield code="c">
-			تأليف السيد محمد رشيد رضا.
-		</subfield>
-	</datafield>
-	<datafield ind1="3" ind2="0" tag="880">
-		<subfield code="6">
-			246-04/(3/r
-		</subfield>
-		<subfield code="a">
-			تفسير المنار
-		</subfield>
-	</datafield>
-	<datafield ind1="1" ind2=" " tag="880">
-		<subfield code="6">
-			246-05/(3/r
-		</subfield>
-		<subfield code="i">
-			Subtitle on volume 2:
-		</subfield>
-		<subfield code="a">
-			تفسير سلفي أثري مدني عصري إرشادي إجتماعي سياسي
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2=" " tag="880">
-		<subfield code="6">
-			250-06/(3/r
-		</subfield>
-		<subfield code="a">
-			الطبعة الأولى.
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2="1" tag="880">
-		<subfield code="6">
-			264-07/(3/r
-		</subfield>
-		<subfield code="a">
-			مصر :
-		</subfield>
-		<subfield code="b">
-			مطبعة المنار،
-		</subfield>
-		<subfield code="c">
-			1324-1346 هـ.، [1906-1927؟ م.]
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2=" " tag="880">
-		<subfield code="6">
-			300-08/(3/r
-		</subfield>
-		<subfield code="a">
-			8 أجزاء ؛
-		</subfield>
-		<subfield code="c">
-			24 سم
-		</subfield>
-	</datafield>
-	<datafield ind1="1" ind2=" " tag="880">
-		<subfield code="6">
-			700-09/(3/r
-		</subfield>
-		<subfield code="a">
-			عبده، محمد،
-		</subfield>
-		<subfield code="d">
-			1849-1905،
-		</subfield>
-		<subfield code="e">
-			مؤلف. 
-		</subfield>
-		<subfield code="4">
-			aut.
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2=" " tag="959">
-		<subfield code="a">
-			NNU
-		</subfield>
-		<subfield code="b">
-			WEB
-		</subfield>
-		<subfield code="c">
-			GENI
-		</subfield>
-		<subfield code="t">
-			0
-		</subfield>
-		<subfield code="m">
-			Electronic access
-		</subfield>
-		<subfield code="s">
-			01
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2=" " tag="999">
-		<subfield code="i">
-			LeBAU_b12377740
-		</subfield>
-		<subfield code="s">
-			aub_aco000005:v.1
-		</subfield>
-		<subfield code="s">
-			aub_aco000006:v.2
-		</subfield>
-		<subfield code="s">
-			aub_aco000007:v.3
-		</subfield>
-		<subfield code="s">
-			aub_aco000008:v.4
-		</subfield>
-		<subfield code="s">
-			aub_aco000009:v.5
-		</subfield>
-		<subfield code="s">
-			aub_aco000010:v.6
-		</subfield>
-	</datafield>
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<collection xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.loc.gov/MARC21/slim
+        http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd"
+    xmlns="http://www.loc.gov/MARC21/slim">
+<record>
+  <leader>00287cam a2200565 ia4500</leader>
+  <controlfield tag="001">b12377740</controlfield>
+  <controlfield tag="003">LeBAU</controlfield>
+  <controlfield tag="005">20140324</controlfield>
+  <controlfield tag="008">970304m19061927ua            ||0 0 ara d</controlfield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">ocn784289451</subfield>
+  </datafield>
+  <datafield tag="040" ind1=" " ind2=" ">
+    <subfield code="a">LEAUB</subfield>
+    <subfield code="b">ara</subfield>
+    <subfield code="e">rda</subfield>
+    <subfield code="c">LEAUB</subfield>
+    <subfield code="d">LEAUB</subfield>
+  </datafield>
+  <datafield tag="082" ind1="0" ind2="4">
+    <subfield code="a">297.207</subfield>
+    <subfield code="2">20</subfield>
+  </datafield>
+  <datafield tag="100" ind1="0" ind2=" ">
+    <subfield code="6">880-01</subfield>
+    <subfield code="a">Muḥammad Rashīd Riḍā,</subfield>
+    <subfield code="d">1865-1935،</subfield>
+    <subfield code="e">author.</subfield>
+  </datafield>
+  <datafield tag="240" ind1="1" ind2="0">
+    <subfield code="6">880-02</subfield>
+    <subfield code="a">Qur’an. tafāsīr</subfield>
+  </datafield>
+  <datafield tag="245" ind1="1" ind2="0">
+    <subfield code="6">880-03</subfield>
+    <subfield code="a">Tafsīr al-Qurʼān al-hakīm al-mushtahir bi-ism Tafsīr al-Manār /</subfield>
+    <subfield code="c">ta’līf al-Sayyid Muḥammad Rashīd Riḍā.</subfield>
+  </datafield>
+  <datafield tag="246" ind1="3" ind2="0">
+    <subfield code="6">880-04</subfield>
+    <subfield code="a">Tafsīr al-Manār</subfield>
+  </datafield>
+  <datafield tag="246" ind1="1" ind2=" ">
+    <subfield code="6">880-05</subfield>
+    <subfield code="a">tafsīr salafī atharī madanī ‘aṣrī irshādī ijtimā‘ī siyāsī</subfield>
+    <subfield code="a">تفسير سلفي أثري مدني عصري إرشادي إجتماعي سياسي</subfield>
+  </datafield>
+  <datafield tag="250" ind1=" " ind2=" ">
+    <subfield code="6">880-06</subfield>
+    <subfield code="a">First edition</subfield>
+  </datafield>
+  <datafield tag="264" ind1=" " ind2="1">
+    <subfield code="6">880-07</subfield>
+    <subfield code="a">Miṣr :</subfield>
+    <subfield code="b">Maṭbaʻat al-Manār,</subfield>
+    <subfield code="c">1324-1346 H., [1906-1927? M.]</subfield>
+  </datafield>
+  <datafield tag="300" ind1=" " ind2=" ">
+    <subfield code="6">880-08</subfield>
+    <subfield code="a">8 volumes ;</subfield>
+    <subfield code="c">24 cm</subfield>
+  </datafield>
+  <datafield tag="336" ind1=" " ind2=" ">
+    <subfield code="a">text</subfield>
+    <subfield code="b">txt</subfield>
+    <subfield code="2">rdacontent</subfield>
+  </datafield>
+  <datafield tag="337" ind1=" " ind2=" ">
+    <subfield code="a">unmediated</subfield>
+    <subfield code="b">n</subfield>
+    <subfield code="2">rdamedia</subfield>
+  </datafield>
+  <datafield tag="338" ind1=" " ind2=" ">
+    <subfield code="a">volume</subfield>
+    <subfield code="b">nc</subfield>
+    <subfield code="2">rdacarrier</subfield>
+  </datafield>
+  <datafield tag="500" ind1=" " ind2=" ">
+    <subfield code="a">"هذا هو التفسير الوحيد الجامع بين صحيح المأثور وصريح المعقول الذي يبين حكم التشريع وسنن الله في الإنسان، وكون القرآن هداية للبشر في كل زمان ومكان، ويوازن بين هدايته وما عليه المسلمون في هذا العصر وقد أعرضوا عنها، وما كان عليه سلفهم المعتصمين بحبلها، مراعي فيه السهولة في التعبير، مجتنبا مزج الكلام بإصطلاحات العلوم والفنون بحيث يفهمه العامة ولا يستغني عنه الخاصة، وهذه هي الطريقة التي جرى عليها في دروسه في الأزهر حكيم الإسلام الأستاذ الإمام الشيخ محمد عبده."--صفحة العنوان.</subfield>
+  </datafield>
+  <datafield tag="505" ind1="0" ind2=" ">
+    <subfield code="a">تفسير القرآن الحكيم المشتهر بإسم تفسير المنار: الجزء الثاني. وفيه خلاصة ما قاله الأستاذ الإمام في دروسه بالجامع الأزهر وقد قرأ أكثر من نصفه قبل طبعه وبعده --الجزء الثالث. أوله "تلك الرسائل" وفيه صفوة ما قاله الأستاذ الإمام --الجزء الرابع. أوله "كل الطعام" وفيه صفوة ما قاله الأستاذ الإمام في دروسه وقد إعتمدنا بعدد الآيات فيه على المصحف المطبوع في ألمانيا وفرقنا بينهما بنقطتين --الجزء الخامس. أوله "المحصنات من النساء" وفيه صفوة ما قاله الأستاذ الإمام في دروسه في الأزهر، وقد إعتمدنا بعدد الآيات فيه على المصحف المطبوع في الآستانة والمصحف المطبوع في ألمانيا وفرقنا بينهما بنقطتين --الجزء السادس. أوله "لا يحب الله الجهر بالسوء" وقد إعتمدنا بعدد الآيات فيه على المصحف المطبوع في الآستانة والمصحف المطبوع في ألمانيا وفرقنا بينهما بنقطتين --الجزء السابع. أوله "لتجدن أشد الناس عداوة" وقد إعتمدنا بعدد الآيات فيه على المصحف المطبوع في الآستانة والمصحف المطبوع في ألمانيا وفرقنا بينهما بنقطتين --الجزء الثامن. أوله "ولو أننا نزلنا إليهم الملائكة" وقد إعتمدنا بعدد الآيات فيه على المصحف المطبوع الآستانة والمصحف المطبوع في ألمانيا وفرقنا بينهما بنقطتين.</subfield>
+  </datafield>
+  <datafield tag="588" ind1=" " ind2=" ">
+    <subfield code="a">الوصف يستند إلى الجزء الأول.</subfield>
+  </datafield>
+  <datafield tag="630" ind1="0" ind2="4">
+    <subfield code="a">قرآن</subfield>
+    <subfield code="x">تفسير وتأويل.</subfield>
+  </datafield>
+  <datafield tag="630" ind1="0" ind2="0">
+    <subfield code="a">Qur'an</subfield>
+    <subfield code="x">Hermeneutics.</subfield>
+  </datafield>
+  <datafield tag="700" ind1="1" ind2=" ">
+    <subfield code="6">880-09</subfield>
+    <subfield code="a">ʻAbduh, Muḥammad,</subfield>
+    <subfield code="d">1849-1905,</subfield>
+    <subfield code="e">author.</subfield>
+  </datafield>
+  <datafield tag="852" ind1=" " ind2=" ">
+    <subfield code="a">Jafet Library</subfield>
+    <subfield code="e">American University of Beirut, Bliss Street , Beirut, Lebanon.</subfield>
+  </datafield>
+  <datafield tag="880" ind1="0" ind2=" ">
+    <subfield code="6">100-01/(3/r</subfield>
+    <subfield code="a">محمد رشيد رضا،</subfield>
+    <subfield code="e">مؤلف. </subfield>
+    <subfield code="4">aut.</subfield>
+  </datafield>
+  <datafield tag="880" ind1="1" ind2="0">
+    <subfield code="6">240-02/(3/r</subfield>
+    <subfield code="a">قرآن. تفاسير</subfield>
+  </datafield>
+  <datafield tag="880" ind1="1" ind2="0">
+    <subfield code="6">245-03/(3/r</subfield>
+    <subfield code="a">تفسير القرآن الحكيم المشتهر بإسم تفسير المنار /</subfield>
+    <subfield code="c">تأليف السيد محمد رشيد رضا.</subfield>
+  </datafield>
+  <datafield tag="880" ind1="3" ind2="0">
+    <subfield code="6">246-04/(3/r</subfield>
+    <subfield code="a">تفسير المنار</subfield>
+  </datafield>
+  <datafield tag="880" ind1="1" ind2=" ">
+    <subfield code="6">246-05/(3/r</subfield>
+    <subfield code="a">Subtitle on volume 2:</subfield>
+    <subfield code="a">tafsīr salafī atharī madanī ‘aṣrī irshādī ijtimā‘ī siyāsī</subfield>
+  </datafield>
+  <datafield tag="880" ind1=" " ind2=" ">
+    <subfield code="6">250-06/(3/r</subfield>
+    <subfield code="a">الطبعة الأولى.</subfield>
+  </datafield>
+  <datafield tag="880" ind1=" " ind2="1">
+    <subfield code="6">264-07/(3/r</subfield>
+    <subfield code="a">مصر :</subfield>
+    <subfield code="b">مطبعة المنار،</subfield>
+    <subfield code="c">1324-1346 هـ.، [1906-1927؟ م.]</subfield>
+  </datafield>
+  <datafield tag="880" ind1=" " ind2=" ">
+    <subfield code="6">300-08/(3/r</subfield>
+    <subfield code="a">8 أجزاء ؛</subfield>
+    <subfield code="c">24 سم</subfield>
+  </datafield>
+  <datafield tag="880" ind1="1" ind2=" ">
+    <subfield code="6">700-09/(3/r</subfield>
+    <subfield code="a">عبده، محمد،</subfield>
+    <subfield code="d">1849-1905،</subfield>
+    <subfield code="e">مؤلف. </subfield>
+    <subfield code="4">aut.</subfield>
+  </datafield>
+  <datafield tag="907" ind1=" " ind2=" ">
+    <subfield code="a">.b12377740</subfield>
+    <subfield code="b">15-10-15</subfield>
+    <subfield code="c">11-05-24</subfield>
+  </datafield>
+  <datafield tag="907" ind1=" " ind2=" ">
+    <subfield code="a">.b12377740</subfield>
+    <subfield code="b">11-10-11</subfield>
+    <subfield code="c">11-05-24</subfield>
+  </datafield>
+  <datafield tag="945" ind1=" " ind2=" ">
+    <subfield code="f">J</subfield>
+    <subfield code="a">297.207:R54tA:v.1:c.1</subfield>
+    <subfield code="g">1</subfield>
+    <subfield code="i">01010243</subfield>
+    <subfield code="j">.i12832856</subfield>
+    <subfield code="l">u0503</subfield>
+  </datafield>
+  <datafield tag="945" ind1=" " ind2=" ">
+    <subfield code="f">J</subfield>
+    <subfield code="a">297.207:R54tA:v.2:c.1</subfield>
+    <subfield code="g">1</subfield>
+    <subfield code="i">01010244</subfield>
+    <subfield code="j">.i12832868</subfield>
+    <subfield code="l">u0503</subfield>
+  </datafield>
+  <datafield tag="945" ind1=" " ind2=" ">
+    <subfield code="f">J</subfield>
+    <subfield code="a">297.207:R54tA:v.3:c.1</subfield>
+    <subfield code="g">1</subfield>
+    <subfield code="i">01010245</subfield>
+    <subfield code="j">.i1283287x</subfield>
+    <subfield code="l">u0503</subfield>
+  </datafield>
+  <datafield tag="945" ind1=" " ind2=" ">
+    <subfield code="f">J</subfield>
+    <subfield code="a">297.207:R54tA:v.4:c.1</subfield>
+    <subfield code="g">1</subfield>
+    <subfield code="i">01010246</subfield>
+    <subfield code="j">.i12832881</subfield>
+    <subfield code="l">u0503</subfield>
+  </datafield>
+  <datafield tag="945" ind1=" " ind2=" ">
+    <subfield code="f">J</subfield>
+    <subfield code="a">297.207:R54tA:v.5:c.1</subfield>
+    <subfield code="g">1</subfield>
+    <subfield code="i">01010247</subfield>
+    <subfield code="j">.i12832893</subfield>
+    <subfield code="l">u0503</subfield>
+  </datafield>
+  <datafield tag="945" ind1=" " ind2=" ">
+    <subfield code="f">J</subfield>
+    <subfield code="a">297.207:R54tA:v.6:c.1</subfield>
+    <subfield code="g">1</subfield>
+    <subfield code="i">01010248</subfield>
+    <subfield code="j">.i1283290x</subfield>
+    <subfield code="l">u0503</subfield>
+  </datafield>
+  <datafield tag="945" ind1=" " ind2=" ">
+    <subfield code="f">J</subfield>
+    <subfield code="a">297.207:R54tA:v.7:c.1</subfield>
+    <subfield code="g">1</subfield>
+    <subfield code="i">01010249</subfield>
+    <subfield code="j">.i12832911</subfield>
+    <subfield code="l">u0503</subfield>
+  </datafield>
+  <datafield tag="945" ind1=" " ind2=" ">
+    <subfield code="f">J</subfield>
+    <subfield code="a">297.207:R54tA:v.8:c.1</subfield>
+    <subfield code="g">1</subfield>
+    <subfield code="i">01010250</subfield>
+    <subfield code="j">.i12832923</subfield>
+    <subfield code="l">u0503</subfield>
+  </datafield>
+  <datafield tag="998" ind1=" " ind2=" ">
+    <subfield code="a">u05</subfield>
+    <subfield code="b">97-03-04</subfield>
+    <subfield code="c">m</subfield>
+    <subfield code="d">a</subfield>
+    <subfield code="e">-</subfield>
+    <subfield code="f">ara</subfield>
+    <subfield code="g">ua </subfield>
+    <subfield code="h">0</subfield>
+    <subfield code="i">8</subfield>
+  </datafield>
 </record>
+</collection>

--- a/work/LeBAU/LeBAU_20151212/marcxml_out/LeBAU_b12395833_marcxml.xml
+++ b/work/LeBAU/LeBAU_20151212/marcxml_out/LeBAU_b12395833_marcxml.xml
@@ -1,288 +1,142 @@
-<?xml version="1.0" encoding="utf-8"?>
-<record xmlns="http://www.loc.gov/MARC21/slim" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd">
-	<leader>
-		01910nam a2200409   4500
-	</leader>
-	<controlfield tag="001">
-		b12395833
-	</controlfield>
-	<controlfield tag="003">
-		LeBAU
-	</controlfield>
-	<controlfield tag="006">
-		m        d        
-	</controlfield>
-	<controlfield tag="007">
-		cr cn |||m|||a
-	</controlfield>
-	<controlfield tag="008">
-		160203s1952    le      o     ||0 0 ara d
-	</controlfield>
-	<datafield ind1=" " ind2=" " tag="040">
-		<subfield code="a">
-			NNU
-		</subfield>
-		<subfield code="b">
-			ara
-		</subfield>
-		<subfield code="e">
-			rda
-		</subfield>
-		<subfield code="c">
-			NNU
-		</subfield>
-	</datafield>
-	<datafield ind1="0" ind2="4" tag="082">
-		<subfield code="a">
-			309.156
-		</subfield>
-		<subfield code="2">
-			20
-		</subfield>
-	</datafield>
-	<datafield ind1="1" ind2=" " tag="100">
-		<subfield code="6">
-			880-01
-		</subfield>
-		<subfield code="a">
-			Ḥannā, Jūrj,
-		</subfield>
-		<subfield code="e">
-			author.
-		</subfield>
-	</datafield>
-	<datafield ind1="1" ind2="0" tag="245">
-		<subfield code="6">
-			880-02
-		</subfield>
-		<subfield code="a">
-			Wāqiʻ al-ʻālam al-ʻArabī /
-		</subfield>
-		<subfield code="c">
-			al-Duktūr Jūrj Ḥannā.
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2="1" tag="264">
-		<subfield code="6">
-			880-03
-		</subfield>
-		<subfield code="a">
-			Bayrūt :
-		</subfield>
-		<subfield code="b">
-			Dār al-ʻIlm lil-Malāyīn,
-		</subfield>
-		<subfield code="c">
-			1952.
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2=" " tag="300">
-		<subfield code="6">
-			880-04
-		</subfield>
-		<subfield code="a">
-			online resource (152 pages p)
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2=" " tag="336">
-		<subfield code="a">
-			text
-		</subfield>
-		<subfield code="2">
-			rdacontent
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2=" " tag="337">
-		<subfield code="a">
-			computer
-		</subfield>
-		<subfield code="2">
-			rdamedia
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2=" " tag="338">
-		<subfield code="a">
-			online resource
-		</subfield>
-		<subfield code="2">
-			rdacarrier
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2=" " tag="500">
-		<subfield code="a">
-			Part of the Arabic Collections Online (ACO) project, contributed by American University of Beirut's Jafet Memorial Library.
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2=" " tag="533">
-		<subfield code="a">
-			Electronic reproduction.
-		</subfield>
-		<subfield code="b">
-			New York, N.Y. :
-		</subfield>
-		<subfield code="c">
-			New York University,
-		</subfield>
-		<subfield code="d">
-			2016.
-		</subfield>
-		<subfield code="5">
-			NNU
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2="4" tag="651">
-		<subfield code="a">
-			البلدان العربية
-		</subfield>
-		<subfield code="x">
-			الاحوال الاقتصادية.
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2="4" tag="651">
-		<subfield code="a">
-			البلدان العربية
-		</subfield>
-		<subfield code="x">
-			السياسة والحكومة.
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2="4" tag="651">
-		<subfield code="a">
-			البلدان العربية
-		</subfield>
-		<subfield code="x">
-			الاحوال الاجتماعية.
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2="0" tag="651">
-		<subfield code="a">
-			Arab countries
-		</subfield>
-		<subfield code="x">
-			Economic conditions.
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2="0" tag="651">
-		<subfield code="a">
-			Arab countries
-		</subfield>
-		<subfield code="x">
-			Politics and government.
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2="0" tag="651">
-		<subfield code="a">
-			Arab countries
-		</subfield>
-		<subfield code="x">
-			Social conditions.
-		</subfield>
-	</datafield>
-	<datafield ind1="2" ind2=" " tag="710">
-		<subfield code="a">
-			Jafet Memorial Library.
-		</subfield>
-	</datafield>
-	<datafield ind1="0" ind2=" " tag="730">
-		<subfield code="a">
-			Arabic Collections Online.
-		</subfield>
-	</datafield>
-	<datafield ind1="0" ind2="8" tag="776">
-		<subfield code="i">
-			Print version:
-		</subfield>
-		<subfield code="a">
-			Ḥannā, Jūrj, author.
-		</subfield>
-		<subfield code="t">
-			Wāqiʻ al-ʻālam al-ʻArabī
-		</subfield>
-		<subfield code="w">
-			(LeBAU)b12395833
-		</subfield>
-	</datafield>
-	<datafield ind1="4" ind2="0" tag="856">
-		<subfield code="u">
-			http://hdl.handle.net/2333.1/189322jj
-		</subfield>
-	</datafield>
-	<datafield ind1="1" ind2=" " tag="880">
-		<subfield code="6">
-			100-01/(3/r
-		</subfield>
-		<subfield code="a">
-			حنا، جورج،
-		</subfield>
-		<subfield code="e">
-			مؤلف. 
-		</subfield>
-		<subfield code="4">
-			aut.
-		</subfield>
-	</datafield>
-	<datafield ind1="1" ind2="0" tag="880">
-		<subfield code="6">
-			245-02/(3/r
-		</subfield>
-		<subfield code="a">
-			واقع العالم العربي /
-		</subfield>
-		<subfield code="c">
-			الدكتور جورج حنا.
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2="1" tag="880">
-		<subfield code="6">
-			264-03/(3/r
-		</subfield>
-		<subfield code="a">
-			بيروت :
-		</subfield>
-		<subfield code="b">
-			دار العلم للملايين،
-		</subfield>
-		<subfield code="c">
-			1952.
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2=" " tag="880">
-		<subfield code="6">
-			300-04/(3/r
-		</subfield>
-		<subfield code="a">
-			152 صفحة ؛
-		</subfield>
-		<subfield code="c">
-			20 سم
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2=" " tag="959">
-		<subfield code="a">
-			NNU
-		</subfield>
-		<subfield code="b">
-			WEB
-		</subfield>
-		<subfield code="c">
-			GENI
-		</subfield>
-		<subfield code="t">
-			0
-		</subfield>
-		<subfield code="m">
-			Electronic access
-		</subfield>
-		<subfield code="s">
-			01
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2=" " tag="999">
-		<subfield code="i">
-			LeBAU_b12395833
-		</subfield>
-		<subfield code="s">
-			aub_aco000004
-		</subfield>
-	</datafield>
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<collection xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.loc.gov/MARC21/slim
+        http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd"
+    xmlns="http://www.loc.gov/MARC21/slim">
+<record>
+  <leader>00207cam a2200373 i 4500</leader>
+  <controlfield tag="001">b12395833</controlfield>
+  <controlfield tag="003">LeBAU</controlfield>
+  <controlfield tag="005">20140407</controlfield>
+  <controlfield tag="008">970324s1952    le            ||0 0 ara d</controlfield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">ocn784296548</subfield>
+  </datafield>
+  <datafield tag="040" ind1=" " ind2=" ">
+    <subfield code="a">LEAUB</subfield>
+    <subfield code="b">ara</subfield>
+    <subfield code="e">rda</subfield>
+    <subfield code="c">LEAUB</subfield>
+    <subfield code="d">LEAUB</subfield>
+  </datafield>
+  <datafield tag="082" ind1="0" ind2="4">
+    <subfield code="a">309.156</subfield>
+    <subfield code="2">20</subfield>
+  </datafield>
+  <datafield tag="100" ind1="1" ind2=" ">
+    <subfield code="6">880-01</subfield>
+    <subfield code="a">Ḥannā, Jūrj,</subfield>
+    <subfield code="e">author.</subfield>
+  </datafield>
+  <datafield tag="245" ind1="1" ind2="0">
+    <subfield code="6">880-02</subfield>
+    <subfield code="a">Wāqiʻ al-ʻālam al-ʻArabī /</subfield>
+    <subfield code="c">al-Duktūr Jūrj Ḥannā.</subfield>
+  </datafield>
+  <datafield tag="264" ind1=" " ind2="1">
+    <subfield code="6">880-03</subfield>
+    <subfield code="a">Bayrūt :</subfield>
+    <subfield code="b">Dār al-ʻIlm lil-Malāyīn,</subfield>
+    <subfield code="c">1952.</subfield>
+  </datafield>
+  <datafield tag="300" ind1=" " ind2=" ">
+    <subfield code="6">880-04</subfield>
+    <subfield code="a">152 pages p</subfield>
+    <subfield code="c">20 cm</subfield>
+  </datafield>
+  <datafield tag="336" ind1=" " ind2=" ">
+    <subfield code="a">text</subfield>
+    <subfield code="b">txt</subfield>
+    <subfield code="2">rdacontent</subfield>
+  </datafield>
+  <datafield tag="337" ind1=" " ind2=" ">
+    <subfield code="a">unmediated</subfield>
+    <subfield code="b">n</subfield>
+    <subfield code="2">rdamedia</subfield>
+  </datafield>
+  <datafield tag="338" ind1=" " ind2=" ">
+    <subfield code="a">volume</subfield>
+    <subfield code="b">nc</subfield>
+    <subfield code="2">rdacarrier</subfield>
+  </datafield>
+  <datafield tag="651" ind1=" " ind2="4">
+    <subfield code="a">البلدان العربية</subfield>
+    <subfield code="x">الاحوال الاقتصادية.</subfield>
+  </datafield>
+  <datafield tag="651" ind1=" " ind2="4">
+    <subfield code="a">البلدان العربية</subfield>
+    <subfield code="x">السياسة والحكومة.</subfield>
+  </datafield>
+  <datafield tag="651" ind1=" " ind2="4">
+    <subfield code="a">البلدان العربية</subfield>
+    <subfield code="x">الاحوال الاجتماعية.</subfield>
+  </datafield>
+  <datafield tag="651" ind1=" " ind2="0">
+    <subfield code="a">Arab countries</subfield>
+    <subfield code="x">Economic conditions.</subfield>
+  </datafield>
+  <datafield tag="651" ind1=" " ind2="0">
+    <subfield code="a">Arab countries</subfield>
+    <subfield code="x">Politics and government.</subfield>
+  </datafield>
+  <datafield tag="651" ind1=" " ind2="0">
+    <subfield code="a">Arab countries</subfield>
+    <subfield code="x">Social conditions.</subfield>
+  </datafield>
+  <datafield tag="852" ind1=" " ind2=" ">
+    <subfield code="a">Jafet Library</subfield>
+    <subfield code="e">American University of Beirut, Bliss Street , Beirut, Lebanon.</subfield>
+  </datafield>
+  <datafield tag="880" ind1="1" ind2=" ">
+    <subfield code="6">100-01/(3/r</subfield>
+    <subfield code="a">حنا، جورج،</subfield>
+    <subfield code="e">مؤلف. </subfield>
+    <subfield code="4">aut.</subfield>
+  </datafield>
+  <datafield tag="880" ind1="1" ind2="0">
+    <subfield code="6">245-02/(3/r</subfield>
+    <subfield code="a">واقع العالم العربي /</subfield>
+    <subfield code="c">الدكتور جورج حنا.</subfield>
+  </datafield>
+  <datafield tag="880" ind1=" " ind2="1">
+    <subfield code="6">264-03/(3/r</subfield>
+    <subfield code="a">بيروت :</subfield>
+    <subfield code="b">دار العلم للملايين،</subfield>
+    <subfield code="c">1952.</subfield>
+  </datafield>
+  <datafield tag="880" ind1=" " ind2=" ">
+    <subfield code="6">300-04/(3/r</subfield>
+    <subfield code="a">152 صفحة ؛</subfield>
+    <subfield code="c">20 سم</subfield>
+  </datafield>
+  <datafield tag="907" ind1=" " ind2=" ">
+    <subfield code="a">.b12395833</subfield>
+    <subfield code="b">15-10-15</subfield>
+    <subfield code="c">11-05-24</subfield>
+  </datafield>
+  <datafield tag="907" ind1=" " ind2=" ">
+    <subfield code="a">.b12395833</subfield>
+    <subfield code="b">11-10-11</subfield>
+    <subfield code="c">11-05-24</subfield>
+  </datafield>
+  <datafield tag="945" ind1=" " ind2=" ">
+    <subfield code="f">J</subfield>
+    <subfield code="a">309.156:H24wA:c.1</subfield>
+    <subfield code="g">1</subfield>
+    <subfield code="i">01012914</subfield>
+    <subfield code="j">.i1285721x</subfield>
+    <subfield code="l">u0503</subfield>
+  </datafield>
+  <datafield tag="998" ind1=" " ind2=" ">
+    <subfield code="a">u05</subfield>
+    <subfield code="b">97-03-24</subfield>
+    <subfield code="c">m</subfield>
+    <subfield code="d">a</subfield>
+    <subfield code="e">-</subfield>
+    <subfield code="f">ara</subfield>
+    <subfield code="g">le </subfield>
+    <subfield code="h">0</subfield>
+    <subfield code="i">1</subfield>
+  </datafield>
 </record>
+</collection>

--- a/work/LeBAU/LeBAU_20151212/marcxml_out/LeBAU_b12444522_marcxml.xml
+++ b/work/LeBAU/LeBAU_20151212/marcxml_out/LeBAU_b12444522_marcxml.xml
@@ -1,259 +1,127 @@
-<?xml version="1.0" encoding="utf-8"?>
-<record xmlns="http://www.loc.gov/MARC21/slim" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd">
-	<leader>
-		01904nam a2200361   4500
-	</leader>
-	<controlfield tag="001">
-		b12444522
-	</controlfield>
-	<controlfield tag="003">
-		LeBAU
-	</controlfield>
-	<controlfield tag="006">
-		m        d        
-	</controlfield>
-	<controlfield tag="007">
-		cr cn |||m|||a
-	</controlfield>
-	<controlfield tag="008">
-		160203s1907    ua c    o     000 0 ara d
-	</controlfield>
-	<datafield ind1=" " ind2=" " tag="040">
-		<subfield code="a">
-			NNU
-		</subfield>
-		<subfield code="b">
-			ara
-		</subfield>
-		<subfield code="e">
-			rda
-		</subfield>
-		<subfield code="c">
-			NNU
-		</subfield>
-	</datafield>
-	<datafield ind1="0" ind2="4" tag="082">
-		<subfield code="a">
-			349.297
-		</subfield>
-		<subfield code="2">
-			20
-		</subfield>
-	</datafield>
-	<datafield ind1="1" ind2=" " tag="100">
-		<subfield code="6">
-			880-01
-		</subfield>
-		<subfield code="a">
-			Hāshimī, al-Sayyid Aḥmad,
-		</subfield>
-		<subfield code="d">
-			1878-1943،
-		</subfield>
-		<subfield code="e">
-			author.
-		</subfield>
-	</datafield>
-	<datafield ind1="1" ind2="0" tag="245">
-		<subfield code="6">
-			880-02
-		</subfield>
-		<subfield code="a">
-			al-Saʻādah al-abadīyah fī al-sharīʻah al-Islāmīyah /
-		</subfield>
-		<subfield code="c">
-			ta’līf Aḥmad al-Hāshimī murāqib madāris Fiktūryā al-Injlīzīyah.
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2="1" tag="264">
-		<subfield code="6">
-			880-03
-		</subfield>
-		<subfield code="a">
-			Miṣr :
-		</subfield>
-		<subfield code="b">
-			Maṭbaʻat al-Saʻādah,
-		</subfield>
-		<subfield code="c">
-			1325 H., [1907 M.]
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2=" " tag="300">
-		<subfield code="6">
-			880-04
-		</subfield>
-		<subfield code="a">
-			online resource (398 pages) :
-		</subfield>
-		<subfield code="b">
-			portrait
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2=" " tag="336">
-		<subfield code="a">
-			text
-		</subfield>
-		<subfield code="2">
-			rdacontent
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2=" " tag="337">
-		<subfield code="a">
-			computer
-		</subfield>
-		<subfield code="2">
-			rdamedia
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2=" " tag="338">
-		<subfield code="a">
-			online resource
-		</subfield>
-		<subfield code="2">
-			rdacarrier
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2=" " tag="500">
-		<subfield code="a">
-			Part of the Arabic Collections Online (ACO) project, contributed by American University of Beirut's Jafet Memorial Library.
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2=" " tag="533">
-		<subfield code="a">
-			Electronic reproduction.
-		</subfield>
-		<subfield code="b">
-			New York, N.Y. :
-		</subfield>
-		<subfield code="c">
-			New York University,
-		</subfield>
-		<subfield code="d">
-			2016.
-		</subfield>
-		<subfield code="5">
-			NNU
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2="4" tag="650">
-		<subfield code="a">
-			الفقه الاسلامي.
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2="0" tag="650">
-		<subfield code="a">
-			Islamic law.
-		</subfield>
-	</datafield>
-	<datafield ind1="2" ind2=" " tag="710">
-		<subfield code="a">
-			Jafet Memorial Library.
-		</subfield>
-	</datafield>
-	<datafield ind1="0" ind2=" " tag="730">
-		<subfield code="a">
-			Arabic Collections Online.
-		</subfield>
-	</datafield>
-	<datafield ind1="0" ind2="8" tag="776">
-		<subfield code="i">
-			Print version:
-		</subfield>
-		<subfield code="a">
-			Hāshimī, al-Sayyid Aḥmad, 1878-1943، author.
-		</subfield>
-		<subfield code="t">
-			al-Saʻādah al-abadīyah fī al-sharīʻah al-Islāmīyah
-		</subfield>
-		<subfield code="w">
-			(LeBAU)b12444522
-		</subfield>
-	</datafield>
-	<datafield ind1="4" ind2="0" tag="856">
-		<subfield code="u">
-			http://hdl.handle.net/2333.1/rr4xh1p1
-		</subfield>
-	</datafield>
-	<datafield ind1="1" ind2=" " tag="880">
-		<subfield code="6">
-			100-01/(3/r
-		</subfield>
-		<subfield code="a">
-			الهاشمي، احمد،
-		</subfield>
-		<subfield code="e">
-			مؤلف. 
-		</subfield>
-		<subfield code="4">
-			aut.
-		</subfield>
-	</datafield>
-	<datafield ind1="1" ind2="0" tag="880">
-		<subfield code="6">
-			245-02/(3/r
-		</subfield>
-		<subfield code="a">
-			السعادة الأبدية في الشريعة الإسلامية /
-		</subfield>
-		<subfield code="c">
-			تأليف أحمد الهاشمي مراقب مدارس فكتوريا الإنجليزية.
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2="1" tag="880">
-		<subfield code="6">
-			264-03/(3/r
-		</subfield>
-		<subfield code="a">
-			مصر :
-		</subfield>
-		<subfield code="b">
-			مطبعة السعادة،
-		</subfield>
-		<subfield code="c">
-			1325 هـ.، [1907 م.]
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2=" " tag="880">
-		<subfield code="6">
-			300-04/(3/r
-		</subfield>
-		<subfield code="a">
-			398 صفحة :
-		</subfield>
-		<subfield code="b">
-			صورة شخصانية ؛
-		</subfield>
-		<subfield code="c">
-			20 سم
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2=" " tag="959">
-		<subfield code="a">
-			NNU
-		</subfield>
-		<subfield code="b">
-			WEB
-		</subfield>
-		<subfield code="c">
-			GENI
-		</subfield>
-		<subfield code="t">
-			0
-		</subfield>
-		<subfield code="m">
-			Electronic access
-		</subfield>
-		<subfield code="s">
-			01
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2=" " tag="999">
-		<subfield code="i">
-			LeBAU_b12444522
-		</subfield>
-		<subfield code="s">
-			aub_aco000003
-		</subfield>
-	</datafield>
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<collection xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.loc.gov/MARC21/slim
+        http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd"
+    xmlns="http://www.loc.gov/MARC21/slim">
+<record>
+  <leader>00187cam a2200325 i 4500</leader>
+  <controlfield tag="001">b12444522</controlfield>
+  <controlfield tag="003">LeBAU</controlfield>
+  <controlfield tag="005">20140516</controlfield>
+  <controlfield tag="008">970512s1907    ua c          000 0 ara d</controlfield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">ocn784320923</subfield>
+  </datafield>
+  <datafield tag="040" ind1=" " ind2=" ">
+    <subfield code="a">LEAUB</subfield>
+    <subfield code="b">ara</subfield>
+    <subfield code="e">rda</subfield>
+    <subfield code="c">LEAUB</subfield>
+    <subfield code="d">LEAUB</subfield>
+  </datafield>
+  <datafield tag="082" ind1="0" ind2="4">
+    <subfield code="a">349.297</subfield>
+    <subfield code="2">20</subfield>
+  </datafield>
+  <datafield tag="100" ind1="1" ind2=" ">
+    <subfield code="6">880-01</subfield>
+    <subfield code="a">Hāshimī, al-Sayyid Aḥmad,</subfield>
+    <subfield code="d">1878-1943،</subfield>
+    <subfield code="e">author.</subfield>
+  </datafield>
+  <datafield tag="245" ind1="1" ind2="0">
+    <subfield code="6">880-02</subfield>
+    <subfield code="a">al-Saʻādah al-abadīyah fī al-sharīʻah al-Islāmīyah /</subfield>
+    <subfield code="c">ta’līf Aḥmad al-Hāshimī murāqib madāris Fiktūryā al-Injlīzīyah.</subfield>
+  </datafield>
+  <datafield tag="264" ind1=" " ind2="1">
+    <subfield code="6">880-03</subfield>
+    <subfield code="a">Miṣr :</subfield>
+    <subfield code="b">Maṭbaʻat al-Saʻādah,</subfield>
+    <subfield code="c">1325 H., [1907 M.]</subfield>
+  </datafield>
+  <datafield tag="300" ind1=" " ind2=" ">
+    <subfield code="6">880-04</subfield>
+    <subfield code="a">398 pages :</subfield>
+    <subfield code="b">portrait ;</subfield>
+    <subfield code="c">20 cm</subfield>
+  </datafield>
+  <datafield tag="336" ind1=" " ind2=" ">
+    <subfield code="a">text</subfield>
+    <subfield code="b">txt</subfield>
+    <subfield code="2">rdacontent</subfield>
+  </datafield>
+  <datafield tag="337" ind1=" " ind2=" ">
+    <subfield code="a">unmediated</subfield>
+    <subfield code="b">n</subfield>
+    <subfield code="2">rdamedia</subfield>
+  </datafield>
+  <datafield tag="338" ind1=" " ind2=" ">
+    <subfield code="a">volume</subfield>
+    <subfield code="b">nc</subfield>
+    <subfield code="2">rdacarrier</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="4">
+    <subfield code="a">الفقه الاسلامي.</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">Islamic law.</subfield>
+  </datafield>
+  <datafield tag="852" ind1=" " ind2=" ">
+    <subfield code="a">Jafet Library</subfield>
+    <subfield code="e">American University of Beirut, Bliss Street , Beirut, Lebanon.</subfield>
+  </datafield>
+  <datafield tag="880" ind1="1" ind2=" ">
+    <subfield code="6">100-01/(3/r</subfield>
+    <subfield code="a">الهاشمي، احمد،</subfield>
+    <subfield code="e">مؤلف. </subfield>
+    <subfield code="4">aut.</subfield>
+  </datafield>
+  <datafield tag="880" ind1="1" ind2="0">
+    <subfield code="6">245-02/(3/r</subfield>
+    <subfield code="a">السعادة الأبدية في الشريعة الإسلامية /</subfield>
+    <subfield code="c">تأليف أحمد الهاشمي مراقب مدارس فكتوريا الإنجليزية.</subfield>
+  </datafield>
+  <datafield tag="880" ind1=" " ind2="1">
+    <subfield code="6">264-03/(3/r</subfield>
+    <subfield code="a">مصر :</subfield>
+    <subfield code="b">مطبعة السعادة،</subfield>
+    <subfield code="c">1325 هـ.، [1907 م.]</subfield>
+  </datafield>
+  <datafield tag="880" ind1=" " ind2=" ">
+    <subfield code="6">300-04/(3/r</subfield>
+    <subfield code="a">398 صفحة :</subfield>
+    <subfield code="b">صورة شخصانية ؛</subfield>
+    <subfield code="c">20 سم</subfield>
+  </datafield>
+  <datafield tag="907" ind1=" " ind2=" ">
+    <subfield code="a">.b12444522</subfield>
+    <subfield code="b">15-10-15</subfield>
+    <subfield code="c">11-05-24</subfield>
+  </datafield>
+  <datafield tag="907" ind1=" " ind2=" ">
+    <subfield code="a">.b12444522</subfield>
+    <subfield code="b">11-10-11</subfield>
+    <subfield code="c">11-05-24</subfield>
+  </datafield>
+  <datafield tag="945" ind1=" " ind2=" ">
+    <subfield code="f">J</subfield>
+    <subfield code="a">349.297:H34sA:c.1</subfield>
+    <subfield code="g">1</subfield>
+    <subfield code="i">01020027</subfield>
+    <subfield code="j">.i12920885</subfield>
+    <subfield code="l">u0503</subfield>
+  </datafield>
+  <datafield tag="998" ind1=" " ind2=" ">
+    <subfield code="a">u05</subfield>
+    <subfield code="b">97-05-12</subfield>
+    <subfield code="c">m</subfield>
+    <subfield code="d">a</subfield>
+    <subfield code="e">-</subfield>
+    <subfield code="f">ara</subfield>
+    <subfield code="g">ua </subfield>
+    <subfield code="h">0</subfield>
+    <subfield code="i">1</subfield>
+  </datafield>
 </record>
+</collection>

--- a/work/LeBAU/LeBAU_20151212/marcxml_out/LeBAU_b14186871_marcxml.xml
+++ b/work/LeBAU/LeBAU_20151212/marcxml_out/LeBAU_b14186871_marcxml.xml
@@ -1,407 +1,195 @@
-<?xml version="1.0" encoding="utf-8"?>
-<record xmlns="http://www.loc.gov/MARC21/slim" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd">
-	<leader>
-		02969nam a2200529   4500
-	</leader>
-	<controlfield tag="001">
-		b14186871
-	</controlfield>
-	<controlfield tag="003">
-		LeBAU
-	</controlfield>
-	<controlfield tag="006">
-		m        d        
-	</controlfield>
-	<controlfield tag="007">
-		cr cn |||m|||a
-	</controlfield>
-	<controlfield tag="008">
-		160203s1952    ua ah   ob    ||0 0 ara d
-	</controlfield>
-	<datafield ind1=" " ind2=" " tag="037">
-		<subfield code="b">
-			Majid Fakhry
-		</subfield>
-		<subfield code="z">
-			40850
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2=" " tag="040">
-		<subfield code="a">
-			NNU
-		</subfield>
-		<subfield code="b">
-			ara
-		</subfield>
-		<subfield code="e">
-			rda
-		</subfield>
-		<subfield code="c">
-			NNU
-		</subfield>
-	</datafield>
-	<datafield ind1="0" ind2="4" tag="082">
-		<subfield code="a">
-			181.07
-		</subfield>
-		<subfield code="2">
-			22
-		</subfield>
-	</datafield>
-	<datafield ind1="1" ind2=" " tag="100">
-		<subfield code="6">
-			880-01
-		</subfield>
-		<subfield code="a">
-			Ibn Sīnā, al-Ḥusayn ibn ʻAbd Allāh,
-		</subfield>
-		<subfield code="d">
-			980-1037,
-		</subfield>
-		<subfield code="e">
-			author.
-		</subfield>
-	</datafield>
-	<datafield ind1="1" ind2="0" tag="245">
-		<subfield code="6">
-			880-02
-		</subfield>
-		<subfield code="a">
-			Aḥwāl al-nafs :
-		</subfield>
-		<subfield code="b">
-			risālah fī al-nafs wa-baqāʼihā wa-maʻādahā /
-		</subfield>
-		<subfield code="c">
-			lil-shaykh al-Ra’īs Ibn Sīnā ; ḥaqqaqahu wa-qaddama ilayhi Aḥmad Fuʼād al-Ahwānī.
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2=" " tag="250">
-		<subfield code="6">
-			880-03
-		</subfield>
-		<subfield code="a">
-			First edition.
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2="1" tag="264">
-		<subfield code="6">
-			880-04
-		</subfield>
-		<subfield code="a">
-			Miṣr :
-		</subfield>
-		<subfield code="b">
-			Dār Iḥyāʼ al-Kutub al-ʻArabīyah,
-		</subfield>
-		<subfield code="c">
-			1371 H. = 1952 M.
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2=" " tag="300">
-		<subfield code="6">
-			880-05
-		</subfield>
-		<subfield code="a">
-			online resource (203 pages) :
-		</subfield>
-		<subfield code="b">
-			illustrations, facsimilies
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2=" " tag="336">
-		<subfield code="a">
-			text
-		</subfield>
-		<subfield code="2">
-			rdacontent
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2=" " tag="337">
-		<subfield code="a">
-			computer
-		</subfield>
-		<subfield code="2">
-			rdamedia
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2=" " tag="338">
-		<subfield code="a">
-			online resource
-		</subfield>
-		<subfield code="2">
-			rdacarrier
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2=" " tag="500">
-		<subfield code="a">
-			Part of the Arabic Collections Online (ACO) project, contributed by American University of Beirut's Jafet Memorial Library.
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2=" " tag="504">
-		<subfield code="a">
-			يتضمن مراجع ببليوغرافية.
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2=" " tag="533">
-		<subfield code="a">
-			Electronic reproduction.
-		</subfield>
-		<subfield code="b">
-			New York, N.Y. :
-		</subfield>
-		<subfield code="c">
-			New York University,
-		</subfield>
-		<subfield code="d">
-			2016.
-		</subfield>
-		<subfield code="5">
-			NNU
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2="4" tag="650">
-		<subfield code="a">
-			النفس (فلسفة)
-		</subfield>
-		<subfield code="v">
-			اعمال قديمة حتى 1800.
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2="4" tag="650">
-		<subfield code="a">
-			الفلسفة الاسلامية
-		</subfield>
-		<subfield code="v">
-			اعمال قديمة حتى 1800.
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2="4" tag="650">
-		<subfield code="a">
-			الروح
-		</subfield>
-		<subfield code="x">
-			الاسلام.
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2="4" tag="650">
-		<subfield code="a">
-			علم النفس
-		</subfield>
-		<subfield code="v">
-			اعمال قديمة حتى 1800.
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2="0" tag="650">
-		<subfield code="a">
-			Self (Philosophy)
-		</subfield>
-		<subfield code="v">
-			Early works to 1800.
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2="0" tag="650">
-		<subfield code="a">
-			Islamic philosophy
-		</subfield>
-		<subfield code="v">
-			Early works to 1800.
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2="0" tag="650">
-		<subfield code="a">
-			Soul
-		</subfield>
-		<subfield code="x">
-			Islam.
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2="0" tag="650">
-		<subfield code="a">
-			Psychology
-		</subfield>
-		<subfield code="v">
-			Early works to 1850.
-		</subfield>
-	</datafield>
-	<datafield ind1="1" ind2=" " tag="700">
-		<subfield code="6">
-			880-06
-		</subfield>
-		<subfield code="a">
-			Ahwānī, Muḥammad Fu’ād,
-		</subfield>
-		<subfield code="d">
-			-1970،
-		</subfield>
-		<subfield code="e">
-			Annotator.
-		</subfield>
-	</datafield>
-	<datafield ind1="1" ind2=" " tag="700">
-		<subfield code="6">
-			880-07
-		</subfield>
-		<subfield code="a">
-			Ahwānī, Muḥammad Fu’ād,
-		</subfield>
-		<subfield code="d">
-			-1970،
-		</subfield>
-		<subfield code="e">
-			Author of introduction
-		</subfield>
-		<subfield code="4">
-			aui.
-		</subfield>
-	</datafield>
-	<datafield ind1="2" ind2=" " tag="710">
-		<subfield code="a">
-			Jafet Memorial Library.
-		</subfield>
-	</datafield>
-	<datafield ind1="0" ind2=" " tag="730">
-		<subfield code="a">
-			Arabic Collections Online.
-		</subfield>
-	</datafield>
-	<datafield ind1="0" ind2="8" tag="776">
-		<subfield code="i">
-			Print version:
-		</subfield>
-		<subfield code="a">
-			Ibn Sīnā, al-Ḥusayn ibn ʻAbd Allāh, 980-1037, author.
-		</subfield>
-		<subfield code="t">
-			Aḥwāl al-nafs
-		</subfield>
-		<subfield code="w">
-			(LeBAU)b14186871
-		</subfield>
-	</datafield>
-	<datafield ind1="4" ind2="0" tag="856">
-		<subfield code="u">
-			http://hdl.handle.net/2333.1/wh70s26g
-		</subfield>
-	</datafield>
-	<datafield ind1="1" ind2=" " tag="880">
-		<subfield code="6">
-			100-01/(3/r
-		</subfield>
-		<subfield code="a">
-			ابن سينا، ابو علي الحسين بن عبد الله،
-		</subfield>
-		<subfield code="d">
-			980-1037،
-		</subfield>
-		<subfield code="e">
-			مؤلف. 
-		</subfield>
-		<subfield code="4">
-			aut.
-		</subfield>
-	</datafield>
-	<datafield ind1="1" ind2="0" tag="880">
-		<subfield code="6">
-			245-02/(3/r
-		</subfield>
-		<subfield code="a">
-			أحوال النفس :
-		</subfield>
-		<subfield code="b">
-			رسالة في النفس وبقائها ومعادها /
-		</subfield>
-		<subfield code="c">
-			للشيخ الرئيس إبن سينا ؛ حققه وقدم إليه أحمد فؤاد الأهواني.
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2=" " tag="880">
-		<subfield code="6">
-			250-03/(3/r
-		</subfield>
-		<subfield code="a">
-			الطبعة الأولى.
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2="1" tag="880">
-		<subfield code="6">
-			264-04/(3/r
-		</subfield>
-		<subfield code="a">
-			مصر :
-		</subfield>
-		<subfield code="b">
-			دار إحياء الكتب العربية،
-		</subfield>
-		<subfield code="c">
-			1371 هـ. = 1952 م.
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2=" " tag="880">
-		<subfield code="6">
-			300-05/(3/r
-		</subfield>
-		<subfield code="a">
-			203 صفحات :
-		</subfield>
-		<subfield code="b">
-			مصورات، صور طبق الأصل ؛
-		</subfield>
-		<subfield code="c">
-			24 سم
-		</subfield>
-	</datafield>
-	<datafield ind1="1" ind2=" " tag="880">
-		<subfield code="6">
-			700-06/(3/r
-		</subfield>
-		<subfield code="a">
-			الاهواني، احمد فؤاد،
-		</subfield>
-		<subfield code="e">
-			محقق. 
-		</subfield>
-		<subfield code="4">
-			ann.
-		</subfield>
-	</datafield>
-	<datafield ind1="1" ind2=" " tag="880">
-		<subfield code="6">
-			700-07/(3/r
-		</subfield>
-		<subfield code="a">
-			الاهواني، احمد فؤاد،
-		</subfield>
-		<subfield code="e">
-			مؤلف مقدمة. 
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2=" " tag="959">
-		<subfield code="a">
-			NNU
-		</subfield>
-		<subfield code="b">
-			WEB
-		</subfield>
-		<subfield code="c">
-			GENI
-		</subfield>
-		<subfield code="t">
-			0
-		</subfield>
-		<subfield code="m">
-			Electronic access
-		</subfield>
-		<subfield code="s">
-			01
-		</subfield>
-	</datafield>
-	<datafield ind1=" " ind2=" " tag="999">
-		<subfield code="i">
-			LeBAU_b14186871
-		</subfield>
-		<subfield code="s">
-			aub_aco000001
-		</subfield>
-	</datafield>
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<collection xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.loc.gov/MARC21/slim
+        http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd"
+    xmlns="http://www.loc.gov/MARC21/slim">
+<record>
+  <leader>00257cam a2200493 i 4500</leader>
+  <controlfield tag="001">b14186871</controlfield>
+  <controlfield tag="003">LeBAU</controlfield>
+  <controlfield tag="005">20131025</controlfield>
+  <controlfield tag="008">090227s1952    ua ah    b    ||0 0 ara d</controlfield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">ocn784577279</subfield>
+  </datafield>
+  <datafield tag="037" ind1=" " ind2=" ">
+    <subfield code="b">Majid Fakhry</subfield>
+    <subfield code="z">40850</subfield>
+  </datafield>
+  <datafield tag="040" ind1=" " ind2=" ">
+    <subfield code="a">LEAUB</subfield>
+    <subfield code="b">ara</subfield>
+    <subfield code="e">rda</subfield>
+    <subfield code="c">LEAUB</subfield>
+    <subfield code="d">LEAUB</subfield>
+  </datafield>
+  <datafield tag="082" ind1="0" ind2="4">
+    <subfield code="a">181.07</subfield>
+    <subfield code="2">22</subfield>
+  </datafield>
+  <datafield tag="100" ind1="1" ind2=" ">
+    <subfield code="6">880-01</subfield>
+    <subfield code="a">Ibn Sīnā, al-Ḥusayn ibn ʻAbd Allāh,</subfield>
+    <subfield code="d">980-1037,</subfield>
+    <subfield code="e">author.</subfield>
+  </datafield>
+  <datafield tag="245" ind1="1" ind2="0">
+    <subfield code="6">880-02</subfield>
+    <subfield code="a">Aḥwāl al-nafs :</subfield>
+    <subfield code="b">risālah fī al-nafs wa-baqāʼihā wa-maʻādahā /</subfield>
+    <subfield code="c">lil-shaykh al-Ra’īs Ibn Sīnā ; ḥaqqaqahu wa-qaddama ilayhi Aḥmad Fuʼād al-Ahwānī.</subfield>
+  </datafield>
+  <datafield tag="250" ind1=" " ind2=" ">
+    <subfield code="6">880-03</subfield>
+    <subfield code="a">First edition.</subfield>
+  </datafield>
+  <datafield tag="264" ind1=" " ind2="1">
+    <subfield code="6">880-04</subfield>
+    <subfield code="a">Miṣr :</subfield>
+    <subfield code="b">Dār Iḥyāʼ al-Kutub al-ʻArabīyah,</subfield>
+    <subfield code="c">1371 H. = 1952 M.</subfield>
+  </datafield>
+  <datafield tag="300" ind1=" " ind2=" ">
+    <subfield code="6">880-05</subfield>
+    <subfield code="a">203 pages :</subfield>
+    <subfield code="b">illustrations, facsimilies ;</subfield>
+    <subfield code="c">24 cm</subfield>
+  </datafield>
+  <datafield tag="336" ind1=" " ind2=" ">
+    <subfield code="a">text</subfield>
+    <subfield code="b">txt</subfield>
+    <subfield code="2">rdacontent</subfield>
+  </datafield>
+  <datafield tag="337" ind1=" " ind2=" ">
+    <subfield code="a">unmediated</subfield>
+    <subfield code="b">n</subfield>
+    <subfield code="2">rdamedia</subfield>
+  </datafield>
+  <datafield tag="338" ind1=" " ind2=" ">
+    <subfield code="a">volume</subfield>
+    <subfield code="b">nc</subfield>
+    <subfield code="2">rdacarrier</subfield>
+  </datafield>
+  <datafield tag="504" ind1=" " ind2=" ">
+    <subfield code="a">يتضمن مراجع ببليوغرافية.</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="4">
+    <subfield code="a">النفس (فلسفة)</subfield>
+    <subfield code="v">اعمال قديمة حتى 1800.</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="4">
+    <subfield code="a">الفلسفة الاسلامية</subfield>
+    <subfield code="v">اعمال قديمة حتى 1800.</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="4">
+    <subfield code="a">الروح</subfield>
+    <subfield code="x">الاسلام.</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="4">
+    <subfield code="a">علم النفس</subfield>
+    <subfield code="v">اعمال قديمة حتى 1800.</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">Self (Philosophy)</subfield>
+    <subfield code="v">Early works to 1800.</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">Islamic philosophy</subfield>
+    <subfield code="v">Early works to 1800.</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">Soul</subfield>
+    <subfield code="x">Islam.</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">Psychology</subfield>
+    <subfield code="v">Early works to 1850.</subfield>
+  </datafield>
+  <datafield tag="700" ind1="1" ind2=" ">
+    <subfield code="6">880-06</subfield>
+    <subfield code="a">Ahwānī, Muḥammad Fu’ād,</subfield>
+    <subfield code="d">-1970،</subfield>
+    <subfield code="e">Annotator.</subfield>
+  </datafield>
+  <datafield tag="700" ind1="1" ind2=" ">
+    <subfield code="6">880-07</subfield>
+    <subfield code="a">Ahwānī, Muḥammad Fu’ād,</subfield>
+    <subfield code="d">-1970،</subfield>
+    <subfield code="e">Author of introduction</subfield>
+    <subfield code="4">aui.</subfield>
+  </datafield>
+  <datafield tag="852" ind1=" " ind2=" ">
+    <subfield code="a">Jafet Library</subfield>
+    <subfield code="e">American University of Beirut, Bliss Street , Beirut, Lebanon.</subfield>
+  </datafield>
+  <datafield tag="880" ind1="1" ind2=" ">
+    <subfield code="6">100-01/(3/r</subfield>
+    <subfield code="a">ابن سينا، ابو علي الحسين بن عبد الله،</subfield>
+    <subfield code="d">980-1037،</subfield>
+    <subfield code="e">مؤلف. </subfield>
+    <subfield code="4">aut.</subfield>
+  </datafield>
+  <datafield tag="880" ind1="1" ind2="0">
+    <subfield code="6">245-02/(3/r</subfield>
+    <subfield code="a">أحوال النفس :</subfield>
+    <subfield code="b">رسالة في النفس وبقائها ومعادها /</subfield>
+    <subfield code="c">للشيخ الرئيس إبن سينا ؛ حققه وقدم إليه أحمد فؤاد الأهواني.</subfield>
+  </datafield>
+  <datafield tag="880" ind1=" " ind2=" ">
+    <subfield code="6">250-03/(3/r</subfield>
+    <subfield code="a">الطبعة الأولى.</subfield>
+  </datafield>
+  <datafield tag="880" ind1=" " ind2="1">
+    <subfield code="6">264-04/(3/r</subfield>
+    <subfield code="a">مصر :</subfield>
+    <subfield code="b">دار إحياء الكتب العربية،</subfield>
+    <subfield code="c">1371 هـ. = 1952 م.</subfield>
+  </datafield>
+  <datafield tag="880" ind1=" " ind2=" ">
+    <subfield code="6">300-05/(3/r</subfield>
+    <subfield code="a">203 صفحات :</subfield>
+    <subfield code="b">مصورات، صور طبق الأصل ؛</subfield>
+    <subfield code="c">24 سم</subfield>
+  </datafield>
+  <datafield tag="880" ind1="1" ind2=" ">
+    <subfield code="6">700-06/(3/r</subfield>
+    <subfield code="a">الاهواني، احمد فؤاد،</subfield>
+    <subfield code="e">محقق. </subfield>
+    <subfield code="4">ann.</subfield>
+  </datafield>
+  <datafield tag="880" ind1="1" ind2=" ">
+    <subfield code="6">700-07/(3/r</subfield>
+    <subfield code="a">الاهواني، احمد فؤاد،</subfield>
+    <subfield code="e">مؤلف مقدمة. </subfield>
+  </datafield>
+  <datafield tag="907" ind1=" " ind2=" ">
+    <subfield code="a">.b14186871</subfield>
+    <subfield code="b">15-10-15</subfield>
+    <subfield code="c">11-05-24</subfield>
+  </datafield>
+  <datafield tag="907" ind1=" " ind2=" ">
+    <subfield code="a">.b14186871</subfield>
+    <subfield code="b">11-10-11</subfield>
+    <subfield code="c">11-05-24</subfield>
+  </datafield>
+  <datafield tag="945" ind1=" " ind2=" ">
+    <subfield code="f">J</subfield>
+    <subfield code="a">181.07:I954aA:c.1</subfield>
+    <subfield code="g">1</subfield>
+    <subfield code="i">00432319</subfield>
+    <subfield code="j">.i14913744</subfield>
+    <subfield code="l">u0503</subfield>
+  </datafield>
+  <datafield tag="998" ind1=" " ind2=" ">
+    <subfield code="a">u05</subfield>
+    <subfield code="b">09-02-27</subfield>
+    <subfield code="c">m</subfield>
+    <subfield code="d">a</subfield>
+    <subfield code="e">-</subfield>
+    <subfield code="f">ara</subfield>
+    <subfield code="g">ua </subfield>
+    <subfield code="h">0</subfield>
+    <subfield code="i">1</subfield>
+  </datafield>
 </record>
+</collection>


### PR DESCRIPTION
Remove extra space from five MARCXML records in LeBAU_20151212 that caused records to fail validation.   

Copies of these files were corrected during the publication process, but the corrected files were not written back to the GitHub repo until now.

